### PR TITLE
DSTORE-542 Fix replica placement when overseer role is used in rules

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/rule/Rule.java
+++ b/solr/core/src/java/org/apache/solr/cloud/rule/Rule.java
@@ -202,7 +202,7 @@ public class Rule {
 
       @Override
       public boolean canMatch(Object ruleVal, Object testVal) {
-        return compareNum(ruleVal, testVal) == 1;
+        return testVal != null && compareNum(ruleVal, testVal) == 1;
       }
 
     },
@@ -214,7 +214,7 @@ public class Rule {
 
       @Override
       public boolean canMatch(Object ruleVal, Object testVal) {
-        return compareNum(ruleVal, testVal) == -1;
+        return testVal != null && compareNum(ruleVal, testVal) == -1;
       }
 
       @Override


### PR DESCRIPTION
@UlbabraB @brandwatchsteve I have tested this on openstack, seems to behave as expected with 2 rules e.g.

rule=role:!overseer&rule=host:_,shard:_,replica:<2

it obeys the overseer role, and the other rule constraint.
