### PR TITLE
DSTORE-636 Rewrite configuration of recovery threads to fit the Solr …

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/SolrXmlConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrXmlConfig.java
@@ -283,6 +283,7 @@ public class SolrXmlConfig {
     int distributedConnectionTimeout = UpdateShardHandlerConfig.DEFAULT_DISTRIBUPDATECONNTIMEOUT;
     int updateConnectionsEvictorSleepDelay = UpdateShardHandlerConfig.DEFAULT_UPDATECONNECTIONSEVICTORSLEEPDELAY;
     int maxUpdateConnectionIdleTime = UpdateShardHandlerConfig.DEFAULT_MAXUPDATECONNECTIONIDLETIME;
+    int maxRecoveryThreads = UpdateShardHandlerConfig.DEFAULT_MAXRECOVERYTHREADS;
 
     Object muc = nl.remove("maxUpdateConnections");
     if (muc != null) {
@@ -320,11 +321,17 @@ public class SolrXmlConfig {
       defined = true;
     }
 
+    Object mrt = nl.remove("maxRecoveryThreads");
+    if (mrt != null)  {
+      maxRecoveryThreads = parseInt("maxRecoveryThreads", mrt.toString());
+      defined = true;
+    }
+
     if (!defined && !alwaysDefine)
       return null;
 
     return new UpdateShardHandlerConfig(maxUpdateConnections, maxUpdateConnectionsPerHost, distributedSocketTimeout,
-        distributedConnectionTimeout, updateConnectionsEvictorSleepDelay, maxUpdateConnectionIdleTime);
+        distributedConnectionTimeout, updateConnectionsEvictorSleepDelay, maxUpdateConnectionIdleTime, maxRecoveryThreads);
 
   }
 

--- a/solr/core/src/java/org/apache/solr/update/UpdateShardHandler.java
+++ b/solr/core/src/java/org/apache/solr/update/UpdateShardHandler.java
@@ -16,8 +16,6 @@
  */
 package org.apache.solr.update;
 
-import static java.lang.Integer.parseInt;
-
 import java.lang.invoke.MethodHandles;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
@@ -86,10 +84,11 @@ public class UpdateShardHandler {
     log.trace("Created UpdateShardHandler HTTP client with params: {}", clientParams);
 
     ThreadFactory recoveryThreadFactory = new SolrjNamedThreadFactory("recoveryExecutor");
-    String maxRecoveryThreads = System.getProperty("solr.recovery.threads");
-    if (maxRecoveryThreads != null) {
-      recoveryExecutor = ExecutorUtil.newMDCAwareFixedThreadPool(parseInt(maxRecoveryThreads), recoveryThreadFactory);
+    if (cfg != null && cfg.getMaxRecoveryThreads() > 0) {
+      log.info("Creating recoveryExecutor with pool size {}", cfg.getMaxRecoveryThreads());
+      recoveryExecutor = ExecutorUtil.newMDCAwareFixedThreadPool(cfg.getMaxRecoveryThreads(), recoveryThreadFactory);
     } else {
+      log.info("Creating recoveryExecutor with unbounded pool");
       recoveryExecutor = ExecutorUtil.newMDCAwareCachedThreadPool(recoveryThreadFactory);
     }
   }

--- a/solr/core/src/java/org/apache/solr/update/UpdateShardHandlerConfig.java
+++ b/solr/core/src/java/org/apache/solr/update/UpdateShardHandlerConfig.java
@@ -24,11 +24,13 @@ public class UpdateShardHandlerConfig {
   public static final int DEFAULT_MAXUPDATECONNECTIONSPERHOST = 100000;
   public static final int DEFAULT_UPDATECONNECTIONSEVICTORSLEEPDELAY = 5000;
   public static final int DEFAULT_MAXUPDATECONNECTIONIDLETIME = 40000;
+  public static final int DEFAULT_MAXRECOVERYTHREADS = -1;
 
   public static final UpdateShardHandlerConfig DEFAULT
       = new UpdateShardHandlerConfig(DEFAULT_MAXUPDATECONNECTIONS, DEFAULT_MAXUPDATECONNECTIONSPERHOST,
                                      DEFAULT_DISTRIBUPDATESOTIMEOUT, DEFAULT_DISTRIBUPDATECONNTIMEOUT,
-                                      DEFAULT_UPDATECONNECTIONSEVICTORSLEEPDELAY, DEFAULT_MAXUPDATECONNECTIONIDLETIME);
+                                     DEFAULT_UPDATECONNECTIONSEVICTORSLEEPDELAY, DEFAULT_MAXUPDATECONNECTIONIDLETIME,
+                                     DEFAULT_MAXRECOVERYTHREADS);
 
   private final int maxUpdateConnections;
 
@@ -42,13 +44,17 @@ public class UpdateShardHandlerConfig {
 
   private final int maxUpdateConnectionIdleTime;
 
-  public UpdateShardHandlerConfig(int maxUpdateConnections, int maxUpdateConnectionsPerHost, int distributedSocketTimeout, int distributedConnectionTimeout, int updateConnectionsEvictorSleepDelay, int maxUpdateConnectionIdleTime) {
+  private final int maxRecoveryThreads;
+
+  public UpdateShardHandlerConfig(int maxUpdateConnections, int maxUpdateConnectionsPerHost, int distributedSocketTimeout, int distributedConnectionTimeout,
+                                  int updateConnectionsEvictorSleepDelay, int maxUpdateConnectionIdleTime, int maxRecoveryThreads) {
     this.maxUpdateConnections = maxUpdateConnections;
     this.maxUpdateConnectionsPerHost = maxUpdateConnectionsPerHost;
     this.distributedSocketTimeout = distributedSocketTimeout;
     this.distributedConnectionTimeout = distributedConnectionTimeout;
     this.updateConnectionsEvictorSleepDelay = updateConnectionsEvictorSleepDelay;
     this.maxUpdateConnectionIdleTime = maxUpdateConnectionIdleTime;
+    this.maxRecoveryThreads = maxRecoveryThreads;
   }
 
   public int getMaxUpdateConnectionsPerHost() {
@@ -73,5 +79,9 @@ public class UpdateShardHandlerConfig {
 
   public int getMaxUpdateConnectionIdleTime() {
     return maxUpdateConnectionIdleTime;
+  }
+
+  public int getMaxRecoveryThreads() {
+    return maxRecoveryThreads;
   }
 }

--- a/solr/test-framework/src/java/org/apache/solr/util/TestHarness.java
+++ b/solr/test-framework/src/java/org/apache/solr/util/TestHarness.java
@@ -177,7 +177,8 @@ public class TestHarness extends BaseTestHarness {
     UpdateShardHandlerConfig updateShardHandlerConfig
         = new UpdateShardHandlerConfig(UpdateShardHandlerConfig.DEFAULT_MAXUPDATECONNECTIONS,
                                        UpdateShardHandlerConfig.DEFAULT_MAXUPDATECONNECTIONSPERHOST,
-                                       30000, 30000, 5000, 50000);
+                                       30000, 30000, 5000, 50000,
+                                       UpdateShardHandlerConfig.DEFAULT_MAXRECOVERYTHREADS);
     return new NodeConfig.NodeConfigBuilder("testNode", loader)
         .setUseSchemaCache(Boolean.getBoolean("shareSchema"))
         .setCloudConfig(cloudConfig)


### PR DESCRIPTION
…way.

To use this, the following fragment needs to be added to solr.xml

```
  <updateshardhandler>
    <int name="maxRecoveryThreads">${solr.recovery.threads:4}</int>
  </updateshardhandler>
```