### PR TITLE
Support setting a fixed write rate throttle for ConcurrentMergeScheduler

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/ConcurrentMergeScheduler.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ConcurrentMergeScheduler.java
@@ -117,7 +117,7 @@ public class ConcurrentMergeScheduler extends MergeScheduler {
   protected double targetMBPerSec = START_MB_PER_SEC;
 
   /** true if we should rate-limit writes for each merge */
-  private boolean doAutoIOThrottle = false;
+  private boolean doAutoIOThrottle = true;
 
   private double forceMergeMBPerSec = Double.POSITIVE_INFINITY;
 

--- a/solr/core/src/java/org/apache/solr/update/SolrIndexConfig.java
+++ b/solr/core/src/java/org/apache/solr/update/SolrIndexConfig.java
@@ -372,16 +372,16 @@ public class SolrIndexConfig implements MapSerializable {
       // LUCENE-5080: these two setters are removed, so we have to invoke setMaxMergesAndThreads
       // if someone has them configured.
       if (scheduler instanceof ConcurrentMergeScheduler) {
+        ConcurrentMergeScheduler cmScheduler = (ConcurrentMergeScheduler) scheduler;
         NamedList args = mergeSchedulerInfo.initArgs.clone();
         Integer maxMergeCount = (Integer) args.remove("maxMergeCount");
         if (maxMergeCount == null) {
-          maxMergeCount = ((ConcurrentMergeScheduler) scheduler).getMaxMergeCount();
+          maxMergeCount = cmScheduler.getMaxMergeCount();
         }
         Integer maxThreadCount = (Integer) args.remove("maxThreadCount");
         if (maxThreadCount == null) {
-          maxThreadCount = ((ConcurrentMergeScheduler) scheduler).getMaxThreadCount();
+          maxThreadCount = cmScheduler.getMaxThreadCount();
         }
-        ConcurrentMergeScheduler cmScheduler = (ConcurrentMergeScheduler)scheduler;
         cmScheduler.setMaxMergesAndThreads(maxMergeCount, maxThreadCount);
         Boolean autoIOThrottle = (Boolean) args.remove("autoIOThrottle");
         if (autoIOThrottle != null) {

--- a/solr/core/src/java/org/apache/solr/update/SolrIndexConfig.java
+++ b/solr/core/src/java/org/apache/solr/update/SolrIndexConfig.java
@@ -381,7 +381,16 @@ public class SolrIndexConfig implements MapSerializable {
         if (maxThreadCount == null) {
           maxThreadCount = ((ConcurrentMergeScheduler) scheduler).getMaxThreadCount();
         }
-        ((ConcurrentMergeScheduler)scheduler).setMaxMergesAndThreads(maxMergeCount, maxThreadCount);
+        ConcurrentMergeScheduler cmScheduler = (ConcurrentMergeScheduler)scheduler;
+        cmScheduler.setMaxMergesAndThreads(maxMergeCount, maxThreadCount);
+        Boolean autoIOThrottle = (Boolean) args.remove("autoIOThrottle");
+        if (autoIOThrottle != null) {
+          if (autoIOThrottle) {
+            cmScheduler.enableAutoIOThrottle();
+          } else {
+            cmScheduler.disableAutoIOThrottle();
+          }
+        }
         SolrPluginUtils.invokeSetters(scheduler, args);
       } else {
         SolrPluginUtils.invokeSetters(scheduler, mergeSchedulerInfo.initArgs);


### PR DESCRIPTION
This should be a more-acceptable change for the quick-fix we just did (once we know that fix did help)