### PR TITLE
Topdocs patch

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/ValueSourceParser.java
+++ b/solr/core/src/java/org/apache/solr/search/ValueSourceParser.java
@@ -64,6 +64,7 @@ import org.apache.solr.search.facet.StddevAgg;
 import org.apache.solr.search.facet.SumAgg;
 import org.apache.solr.search.facet.SumsqAgg;
 import org.apache.solr.search.facet.RelatednessAgg;
+import org.apache.solr.search.facet.TopDocsAgg;
 import org.apache.solr.search.facet.UniqueAgg;
 import org.apache.solr.search.facet.UniqueBlockAgg;
 import org.apache.solr.search.facet.VarianceAgg;
@@ -1039,7 +1040,7 @@ public abstract class ValueSourceParser implements NamedListInitializedPlugin {
     });
 
     addParser("agg_percentile", new PercentileAgg.Parser());
-    
+
     addParser("agg_" + RelatednessAgg.NAME, new ValueSourceParser() {
       @Override
       public ValueSource parse(FunctionQParser fp) throws SyntaxError {
@@ -1051,6 +1052,8 @@ public abstract class ValueSourceParser implements NamedListInitializedPlugin {
       }
     });
     
+    addParser("agg_topdocs", new TopDocsAgg.Parser());
+
     addParser("childfield", new ChildFieldValueSourceParser());
   }
 

--- a/solr/core/src/java/org/apache/solr/search/facet/FacetRequest.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/FacetRequest.java
@@ -459,6 +459,8 @@ abstract class FacetParser<FacetRequestT extends FacetRequest> {
       return parseQueryFacet(key, args);
     } else if ("range".equals(type)) {
       return parseRangeFacet(key, args);
+    } else if ("topdocs".equals(type)) {
+      return TopDocsAgg.AggParser.parse(args);
     }
 
     AggValueSource stat = parseStat(key, type, args);

--- a/solr/core/src/test/org/apache/solr/search/facet/TestJsonFacets.java
+++ b/solr/core/src/test/org/apache/solr/search/facet/TestJsonFacets.java
@@ -886,6 +886,18 @@ public class TestJsonFacets extends SolrTestCaseHS {
         , "debug/facet-trace=="  // just test for presence, not exact structure / values
     );
 
+    client.testJQ(params(p, "q", "*:*"
+        , "json.facet", "{" +
+            //      "top : 'topdocs(\"*:*\",0,3,\"${cat_s} desc\",\"id,*_s\")' " +
+            //      "top : 'topdocs(\"*:*\")'" +
+            //      "top : { topdocs : '${cat_s}:B' } " +
+            "topA : { type:topdocs, query:'${cat_s}:A', sort:'num_d desc', limit:10, fields:'id,*_s,mynum:${num_d}' } " +
+            ",topB: { type:topdocs, query:'${cat_s}:B', sort:'num_d desc', limit:10, fields:'id,*_s,mynum:${num_d}' } " +
+            "}"
+        )
+        , "facets=={}"
+    );
+
 
     // straight query facets
     client.testJQ(params(p, "q", "*:*"


### PR DESCRIPTION
This takes the patch from SOLR-7830 and updates it for Solr 7, then adds support for distributed search.

It allows us to fetch N docs within each facet bucket, with configurable sorting, limiting and field list selection (default is return all-fields).

The limitation is that you can only sort the topdocs by fields that you're returning (which is fine if you're returning all-fields) and you can't sort by a function. Also doesn't support offset, but that seems a niche requirement for getting topdocs in a facet.