### PR TITLE
Unit test fix

### DIFF
--- a/solr/core/src/test/org/apache/solr/update/SolrIndexConfigTest.java
+++ b/solr/core/src/test/org/apache/solr/update/SolrIndexConfigTest.java
@@ -94,7 +94,7 @@ public class SolrIndexConfigTest extends SolrTestCaseJ4 {
     ConcurrentMergeScheduler ms = (ConcurrentMergeScheduler)  iwc.getMergeScheduler();
     assertEquals("ms.maxMergeCount", 987, ms.getMaxMergeCount());
     assertEquals("ms.maxThreadCount", 42, ms.getMaxThreadCount());
-    assertEquals("ms.isAutoIOThrottle", true, ms.getAutoIOThrottle());
+    assertEquals("ms.isAutoIOThrottle", false, ms.getAutoIOThrottle());
 
   }
 


### PR DESCRIPTION
Fixing default for doAutoIOThrottle / isAutoIOThrottle in recent unit test, to match BW specific hard-coding