### PR TITLE
Fix topdocs to correctly filter results by containing bucket docs

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/facet/TopDocsAgg.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/TopDocsAgg.java
@@ -277,6 +277,7 @@ public class TopDocsAgg extends AggValueSource {
       BooleanQuery.Builder builder = new BooleanQuery.Builder();
       builder.add(query, BooleanClause.Occur.MUST);
       builder.add(slotQuery, BooleanClause.Occur.FILTER);
+      builder.add(fcontext.base.getTopFilter(), BooleanClause.Occur.FILTER);
       Query finalQuery = builder.build();
 
       if (sort == null) sort = Sort.RELEVANCE;


### PR DESCRIPTION
This bug occurred when _not_ using term/field facets, because those do actually apply the right filtering down to their subfacets and aggregates like topdocs, but it wasn't correct for query-facets and range-facets (I tested both and confirmed they were wrong, and now all work correctly).