### PR TITLE
Add SOLR-11556 to the build

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
@@ -952,6 +952,9 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
 
       Map<String, Object> params = copy(req.getParams(), null, NAME, COLLECTION_PROP, CoreAdminParams.COMMIT_NAME);
       params.put(CoreAdminParams.BACKUP_LOCATION, location);
+      if ( repo != null ) {
+        params.put(CoreAdminParams.BACKUP_REPOSITORY, repo);
+      }
       params.put(CollectionAdminParams.INDEX_BACKUP_STRATEGY, strategy);
       return params;
     }),
@@ -1000,6 +1003,9 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
 
       Map<String, Object> params = copy(req.getParams(), null, NAME, COLLECTION_PROP);
       params.put(CoreAdminParams.BACKUP_LOCATION, location);
+      if ( repo != null ) {
+        params.put(CoreAdminParams.BACKUP_REPOSITORY, repo);
+      }
       // from CREATE_OP:
       copy(req.getParams(), params, COLL_CONF, REPLICATION_FACTOR, MAX_SHARDS_PER_NODE, STATE_FORMAT,
           AUTO_ADD_REPLICAS, CREATE_NODE_SET, CREATE_NODE_SET_SHUFFLE);


### PR DESCRIPTION
This patch allows for multiple backup repositories to be defined, and to
work, more can be found [here](https://issues.apache.org/jira/browse/SOLR-11556)