### PR TITLE
Add SOLR-11556 to the build

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
@@ -991,6 +991,9 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
 
       Map<String, Object> params = copy(req.getParams(), null, NAME, COLLECTION_PROP, CoreAdminParams.COMMIT_NAME);
       params.put(CoreAdminParams.BACKUP_LOCATION, location);
+      if ( repo != null ) {
+        params.put(CoreAdminParams.BACKUP_REPOSITORY, repo);
+      }
       params.put(CollectionAdminParams.INDEX_BACKUP_STRATEGY, strategy);
       return params;
     }),
@@ -1043,6 +1046,9 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
 
       Map<String, Object> params = copy(req.getParams(), null, NAME, COLLECTION_PROP);
       params.put(CoreAdminParams.BACKUP_LOCATION, location);
+      if ( repo != null ) {
+        params.put(CoreAdminParams.BACKUP_REPOSITORY, repo);
+      }
       // from CREATE_OP:
       copy(req.getParams(), params, COLL_CONF, REPLICATION_FACTOR, NRT_REPLICAS, TLOG_REPLICAS,
           PULL_REPLICAS, MAX_SHARDS_PER_NODE, STATE_FORMAT, AUTO_ADD_REPLICAS, CREATE_NODE_SET, CREATE_NODE_SET_SHUFFLE);


### PR DESCRIPTION
This patch allows for multiple backup repositories to be defined and the
ability to specify which repository you want to use. This also makes the 
repository as a functionality work as it's currently broken.

This is only a part of the actual Solr Patch, as it appears that most of
it is for code outside of this solr version, and this patch is in our
7.4 build and works