### PR TITLE
Make scrape return early if failure

### DIFF
--- a/solr/contrib/prometheus-exporter/src/java/org/apache/solr/prometheus/scraper/SolrScraper.java
+++ b/solr/contrib/prometheus-exporter/src/java/org/apache/solr/prometheus/scraper/SolrScraper.java
@@ -106,7 +106,8 @@ public abstract class SolrScraper implements Closeable {
         queryResponse = client.request(queryRequest, query.getCollection().get());
       }
     } catch (SolrServerException | IOException e) {
-      log.error("failed to request: " + queryRequest.getPath() + " " + e.getMessage());
+      log.error("failed to request: " + queryRequest.getPath() + " " + e.getMessage() + ", no metrics to process.");
+      return samples;
     }
 
     JsonNode jsonNode = OBJECT_MAPPER.readTree((String) queryResponse.get("response"));


### PR DESCRIPTION
If there is a failure in the request to solr, rather than trying to
apply json logic on a null object, return early passing in an empty
metric result.

I have been testing this on live using qs1 as the testing cluster to
scrape.