### PR TITLE
Add jenkinsfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,9 @@
-FROM debian:jessie
+FROM debian:stretch
 
-ARG buildn
+ARG VERSION=0
 
-ARG stage
-ARG int
-
-ENV BUILD_NUMBER=$buildn
-ENV SOLR_VERSION=7.4.0
-
-
-ENV STAGE=$stage
-ENV INT=$int
-
-
-RUN echo $SOLR_VERSION
-RUN echo $BUILD_NUMBER
-
-USER root
-
-RUN echo "deb http://http.debian.net/debian jessie-backports main" | \
-     tee --append /etc/apt/sources.list.d/jessie-backports.list > /dev/null && \ 
+RUN echo "deb http://http.debian.net/debian stretch-backports main" | \
+     tee --append /etc/apt/sources.list.d/stretch-backports.list > /dev/null && \ 
      apt-get update -y && \
      apt-get install -y \
      wget \
@@ -29,7 +13,7 @@ RUN echo "deb http://http.debian.net/debian jessie-backports main" | \
      rubygems \
      build-essential \
      git-core && \
-     apt-get install -y -t jessie-backports openjdk-8-jdk && \
+     apt-get install -y -t stretch-backports openjdk-8-jdk && \
      update-java-alternatives -s java-1.8.0-openjdk-amd64 && \
      apt-get upgrade -y
 
@@ -61,16 +45,6 @@ RUN ant jar
 WORKDIR /ant-ivy/build/artifact/jars
 RUN scp ivy.jar /opt/ant/lib
 
-WORKDIR /usr/local
-ADD . bw-lucene-solr/
-WORKDIR /usr/local/bw-lucene-solr/solr
+WORKDIR /solr-main/solr/
 RUN ant ivy-bootstrap && \
-   ant clean compile dist package
-
-
-WORKDIR /usr/local/bw-lucene-solr/solr/package
-
-
-RUN fpm --description "Brandwatch Solr distribution" --name solr -v $SOLR_VERSION-SNAPSHOT-bwbuild${BUILD_NUMBER} --prefix /opt -s tar -t deb solr-$SOLR_VERSION-SNAPSHOT.tgz
-RUN curl http://apt.service0.btn1.bwcom.net/packages -u $INT -F my_file=@solr_$SOLR_VERSION-SNAPSHOT-bwbuild${BUILD_NUMBER}_amd64.deb -F name=solr_$SOLR_VERSION-SNAPSHOT-bwbuild${BUILD_NUMBER}_amd64.deb
-RUN curl https://aptly.stage.brandwatch.net/packages -u $STAGE -F my_file=@solr_$SOLR_VERSION-SNAPSHOT-bwbuild${BUILD_NUMBER}_amd64.deb -F name=solr_$SOLR_VERSION-SNAPSHOT-bwbuild${BUILD_NUMBER}_amd64.deb
+    ant clean compile dist package

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-ARG REPO=""
-ARG MAJOR_VERSION=latest
-FROM ${REPO}/ant-base:${MAJOR_VERSION}
+ARG REPO
+ARG ANT_VERSION
+FROM ${REPO}/ant-base:${ANT_VERSION}
 
-ADD . /bw-lucene-solr/
+COPY . /bw-lucene-solr/
 WORKDIR /bw-lucene-solr/solr/
 RUN ant ivy-bootstrap && \
-    ant clean compile dist package
+    ant --noconfig -Dtests.badapples=false clean dist package

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,5 @@ FROM ${REPO}/ant-base:${MAJOR_VERSION}
 
 ADD . /bw-lucene-solr/
 WORKDIR /bw-lucene-solr/solr/
-RUN ls
 RUN ant ivy-bootstrap && \
     ant clean compile dist package

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,50 +1,9 @@
-FROM debian:stretch
+ARG REPO=""
+ARG MAJOR_VERSION=latest
+FROM ${REPO}/ant-base:${MAJOR_VERSION}
 
-ARG VERSION=0
-
-RUN echo "deb http://http.debian.net/debian stretch-backports main" | \
-     tee --append /etc/apt/sources.list.d/stretch-backports.list > /dev/null && \ 
-     apt-get update -y && \
-     apt-get install -y \
-     wget \
-     curl \
-     ruby \
-     ruby-dev \
-     rubygems \
-     build-essential \
-     git-core && \
-     apt-get install -y -t stretch-backports openjdk-8-jdk && \
-     update-java-alternatives -s java-1.8.0-openjdk-amd64 && \
-     apt-get upgrade -y
-
-RUN export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
-
-RUN gem install fpm
-RUN fpm --version
-
-#Installing Apache Ant
-RUN wget http://archive.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.tar.gz
-RUN wget https://www.apache.org/dist/ant/KEYS
-RUN wget https://www.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.tar.gz.asc
-
-#Verify download signature
-RUN gpg --import KEYS
-RUN gpg --verify apache-ant-1.10.5-bin.tar.gz.asc
-
-#Unpack
-RUN tar xvfvz apache-ant-1.10.5-bin.tar.gz
-
-RUN mv apache-ant-1.10.5 /opt/ant
-RUN echo ANT_HOME=/opt/ant >> /etc/environment
-RUN ln -s /opt/ant/bin/ant /usr/bin/ant
-
-#Installing Apache Ivy from git repository
-RUN git clone https://git-wip-us.apache.org/repos/asf/ant-ivy.git
-WORKDIR /ant-ivy
-RUN ant jar
-WORKDIR /ant-ivy/build/artifact/jars
-RUN scp ivy.jar /opt/ant/lib
-
-WORKDIR /solr-main/solr/
+ADD . /bw-lucene-solr/
+WORKDIR /bw-lucene-solr/solr/
+RUN ls
 RUN ant ivy-bootstrap && \
     ant clean compile dist package

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,34 @@
 #!groovy
-def gcpProject =  "bw-prod-platform0"
-def baseImageExist = false
+gcpProject =  "bw-prod-platform0"
+baseImageExist = false
+
+def doesBaseImageExist(String imageVersion) {
+    /*
+        Originally, the docker file would create a new debian image and install
+        all the dependencies needed to build solr, to save time, I've separated
+        the two "stages" into separate docker files, with this, I then do a check
+        to see if the ant-base image exists in our gcr, if it does, then it'll skip
+        building it which should cut down on processing time
+    */
+    echo "Test: ${gcpProject} ... ${imageVersion}"
+    try {
+        img = docker.image("${gcpProject}/ant-base:${imageVersion}").withRun { c ->
+            sh 'ant --help'
+        }
+        return true
+    } catch (Exception e) {
+        return false
+    }
+}
+
+def pushImage(String imageID, String imageVersion) {
+    withEnv(["DOCKER_BUILDKIT=1"]) {
+        img = docker.image(imageID)
+        docker.withRegistry("https://eu.gcr.io", "gcr:${gcpProject}") {
+            img.push(imageVersion)
+        }
+    }
+}
 
 node('docker') {
     stage ('Checkout') {
@@ -18,8 +46,8 @@ node('docker') {
     }
 
     stage ('Build images') {
-        // TODO - make function for pushing images
         baseImageExist = doesBaseImageExist(major_version)
+        /*
         if ( baseImageExist ) {
             echo "Base image exists, using that"
             withEnv(["DOCKER_BUILDKIT=1"]) {
@@ -29,48 +57,23 @@ node('docker') {
                     --build-arg MAJOR_VERSION=${major_version} \
                     -t ${gcpProject}/bw-lucene-solr:${version} .
                 """
-                img = docker.image("${gcpProject}/bw-lucene-solr:${version}")
-                docker.withRegistry("https://eu.gcr.io", "gcr:${gcpProject}") {
-                    img.push(version)
-                }
+                pushImage("${gcpProject}/bw-lucene-solr:${version}", version)
             }
         } else {
             echo "Unable to find base image, building"
             withEnv(["DOCKER_BUILDKIT=1"]) {
                 sh "docker build -f base.Dockerfile -t ${gcpProject}/ant-base:${major_version} ."
-                img = docker.image("${gcpProject}/ant-base:${major_version}")
-                docker.withRegistry("https://eu.gcr.io", "gcr:${gcpProject}") {
-                    img.push(major_version)
-                }
+                pushImage("${gcpProject}/ant-base:${major_version}", major_version)
+
                 sh """ docker build \
                     -f Dockerfile \
                     --build-arg REPO=${gcpProject} \
                     --build-arg MAJOR_VERSION=${major_version} \
                     -t ${gcpProject}/bw-lucene-solr:${version} .
                 """
-                img = docker.image("${gcpProject}/bw-lucene-solr:${version}")
-                docker.withRegistry("https://eu.gcr.io", "gcr:${gcpProject}") {
-                    img.push(version)
-                }
+                pushImage("${gcpProject}/bw-lucene-solr:${version}", version)
             }
         }
-    }
-}
-
-def doesBaseImageExist(String imageVersion) {
-    /*
-        Originally, the docker file would create a new debian image and install
-        all the dependencies needed to build solr, to save time, I've separated
-        the two "stages" into separate docker files, with this, I then do a check
-        to see if the ant-base image exists in our gcr, if it does, then it'll skip
-        building it which should cut down on processing time
-    */
-    try {
-        img = docker.image("${gcpProject}/ant-base:${imageVersion}").withRun { c ->
-            sh 'ant --help'
-        }
-        return true
-    } catch (Exception e) {
-        return false
+        */
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,14 +12,9 @@ node('docker') {
             userRemoteConfigs: scm.userRemoteConfigs
         ])
 
-        // Could change this to be held within a versions.json file if preferred
-        // def branch = env.BRANCH_NAME
-        // TODO - change this when no longer using this branch name
-        test_branch = 'bw_branch_7_7_2'
-        branch_period = test_branch.replaceAll('_', '.')
-        def regex_capture = branch_period =~ /\d.+/
-        version = regex_capture[0]
-        major_version = version.substring(0,1)
+        versions = readJSON file: "versions.json"
+        version = versions["version"]
+        major_version = versions["major_version"]
     }
 
     stage ('Build images') {
@@ -79,4 +74,3 @@ def doesBaseImageExist(String imageVersion) {
         return false
     }
 }
-

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,6 @@
 #!groovy
+def gcpProject =  "bw-prod-platform0"
+def baseImageExist = false
 
 node('docker') {
     stage ('Checkout') {
@@ -9,17 +11,49 @@ node('docker') {
             extensions: scm.extensions + [[$class: 'CleanCheckout']],
             userRemoteConfigs: scm.userRemoteConfigs
         ])
-        branch = env.BRANCH_NAME
+
+        // Could change this to be held within a versions.json file if preferred
+        // def branch = env.BRANCH_NAME
         // TODO - change this when no longer using this branch name
         test_branch = 'bw_branch_7_7_2'
         branch_period = test_branch.replaceAll('_', '.')
         def regex_capture = branch_period =~ /\d.+/
         version = regex_capture[0]
+        major_version = version.substring(0,1)
     }
 
-    stage ('Build and push images') {
-        withEnv(["DOCKER_BUILDKIT=1"]) {
-            sh "docker build -f Dockerfile --build-arg VERSION=${version} ."
+    stage ('Build images') {
+        baseImageExist = doesBaseImageExist(major_version)
+        if ( baseImageExist ) {
+            withEnv(["DOCKER_BUILDKIT=1"]) {
+                sh """ docker build \
+                    -f Dockerfile \
+                    --build-arg REPO=${gcpProject} \
+                    --build-arg MAJOR_VERSION=${major_version} \
+                    -t ${gcpProject}/bw-lucene-solr:${version} .
+                """
+            }
+        } else {
+            withEnv(["DOCKER_BUILDKIT=1"]) {
+                sh "docker build -f base.Dockerfile -t ${gcpProject}/ant-base:${major_version} ."
+                sh """ docker build \
+                    -f Dockerfile \
+                    --build-arg REPO=${gcpProject} \
+                    --build-arg MAJOR_VERSION=${major_version} \
+                    -t ${gcpProject}/bw-lucene-solr:${version} .
+                """
+            }
         }
+    }
+}
+
+def doesBaseImageExist(String imageVersion) {
+    try {
+        img = docker.image("${gcpProject}/ant-base:${imageVersion}").withRun { c ->
+            sh 'ant --help'
+        }
+        return true
+    } catch (Exception e) {
+        return false
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,8 +9,13 @@ node('docker') {
             extensions: scm.extensions + [[$class: 'CleanCheckout']],
             userRemoteConfigs: scm.userRemoteConfigs
         ])
-        test = sh(script: 'printenv', returnStdout: true)
-        echo "${test}"
-        echo "Test: ..." + env.BRANCH_NAME
+        branch = env.BRANCH_NAME
+        test_branch = 'bw_branch_7_7_2'
+        branch_period = test_branch.replaceAll('_', '.')
+        echo "branch_period..." + branch_period
+        def regex_capture = branch_period =~ /\d.+/
+        echo "regex_capture..." + regex_capture
+        version = regex_capture[0]
+        echo "version..." + version
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,16 @@
+#!groovy
+
+node('docker') {
+    stage ('Checkout') {
+        checkout([
+            $class: 'GitSCM',
+            branches: scm.branches,
+            doGenerateSubmoduleConfigurations: scm.doGenerateSubmoduleConfigurations,
+            extensions: scm.extensions + [[$class: 'CleanCheckout']],
+            userRemoteConfigs: scm.userRemoteConfigs
+        ])
+        test = sh(script: 'printenv', returnStdout: true)
+        echo "${test}"
+        echo "Test: ..." + env.BRANCH_NAME
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,8 +23,10 @@ node('docker') {
     }
 
     stage ('Build images') {
+        // TODO - make function for pushing images
         baseImageExist = doesBaseImageExist(major_version)
         if ( baseImageExist ) {
+            echo "Base image exists, using that"
             withEnv(["DOCKER_BUILDKIT=1"]) {
                 sh """ docker build \
                     -f Dockerfile \
@@ -32,22 +34,42 @@ node('docker') {
                     --build-arg MAJOR_VERSION=${major_version} \
                     -t ${gcpProject}/bw-lucene-solr:${version} .
                 """
+                img = docker.image("${gcpProject}/bw-lucene-solr:${version}")
+                docker.withRegistry("https://eu.gcr.io", "gcr:${gcpProject}") {
+                    img.push(version)
+                }
             }
         } else {
+            echo "Unable to find base image, building"
             withEnv(["DOCKER_BUILDKIT=1"]) {
                 sh "docker build -f base.Dockerfile -t ${gcpProject}/ant-base:${major_version} ."
+                img = docker.image("${gcpProject}/ant-base:${major_version}")
+                docker.withRegistry("https://eu.gcr.io", "gcr:${gcpProject}") {
+                    img.push(major_version)
+                }
                 sh """ docker build \
                     -f Dockerfile \
                     --build-arg REPO=${gcpProject} \
                     --build-arg MAJOR_VERSION=${major_version} \
                     -t ${gcpProject}/bw-lucene-solr:${version} .
                 """
+                img = docker.image("${gcpProject}/bw-lucene-solr:${version}")
+                docker.withRegistry("https://eu.gcr.io", "gcr:${gcpProject}") {
+                    img.push(version)
+                }
             }
         }
     }
 }
 
 def doesBaseImageExist(String imageVersion) {
+    /*
+        Originally, the docker file would create a new debian image and install
+        all the dependencies needed to build solr, to save time, I've separated
+        the two "stages" into separate docker files, with this, I then do a check
+        to see if the ant-base image exists in our gcr, if it does, then it'll skip
+        building it which should cut down on processing time
+    */
     try {
         img = docker.image("${gcpProject}/ant-base:${imageVersion}").withRun { c ->
             sh 'ant --help'
@@ -57,3 +79,4 @@ def doesBaseImageExist(String imageVersion) {
         return false
     }
 }
+

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,12 +10,16 @@ node('docker') {
             userRemoteConfigs: scm.userRemoteConfigs
         ])
         branch = env.BRANCH_NAME
+        // TODO - change this when no longer using this branch name
         test_branch = 'bw_branch_7_7_2'
         branch_period = test_branch.replaceAll('_', '.')
-        echo "branch_period..." + branch_period
         def regex_capture = branch_period =~ /\d.+/
-        echo "regex_capture..." + regex_capture
         version = regex_capture[0]
-        echo "version..." + version
+    }
+
+    stage ('Build and push images') {
+        withEnv(["DOCKER_BUILDKIT=1"]) {
+            sh "docker build -f Dockerfile --build-arg VERSION=${version} ."
+        }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,24 +1,5 @@
 #!groovy
 gcpProject = "bw-prod-platform0"
-baseImageExists = false
-
-def doesBaseImageExist(String imageVersion) {
-    /*
-        Originally, the docker file would create a new debian image and install
-        all the dependencies needed to build solr, to save time, I've separated
-        the two "stages" into separate docker files, with this, I then do a check
-        to see if the ant-base image exists in our gcr, if it does, then it'll skip
-        building it which should cut down on processing time
-    */
-    try {
-        img = docker.image("${gcpProject}/ant-base:${imageVersion}").withRun { c ->
-            sh 'ant --help'
-        }
-        return true
-    } catch (Exception e) {
-        return false
-    }
-}
 
 def pushImage(String imageID, String imageVersion) {
     buildNumber = "build_${env.BUILD_NUMBER}"
@@ -47,18 +28,13 @@ node('docker') {
     }
 
     stage ('Build images') {
-        baseImageExists = doesBaseImageExist(ant_version)
-        if ( !baseImageExists ) {
-            echo "Unable to find base image, building"
-            withEnv(["DOCKER_BUILDKIT=1"]) {
-                sh """ docker build -f base.Dockerfile \
-                    --build-arg ANT_VERSION=${ant_version} \
-                    -t ${gcpProject}/ant-base:${ant_version} .
-                """
-                pushImage("${gcpProject}/ant-base:${ant_version}", ant_version)
-            }
-        }
         withEnv(["DOCKER_BUILDKIT=1"]) {
+            sh """ docker build -f base.Dockerfile \
+                --build-arg ANT_VERSION=${ant_version} \
+                -t ${gcpProject}/ant-base:${ant_version} .
+            """
+            pushImage("${gcpProject}/ant-base:${ant_version}", ant_version)
+
             sh """ docker build \
                 --build-arg REPO=${gcpProject} \
                 --build-arg ANT_VERSION=${ant_version} \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,6 @@ def doesBaseImageExist(String imageVersion) {
         to see if the ant-base image exists in our gcr, if it does, then it'll skip
         building it which should cut down on processing time
     */
-    echo "Test: ${gcpProject} ... ${imageVersion}"
     try {
         img = docker.image("${gcpProject}/ant-base:${imageVersion}").withRun { c ->
             sh 'ant --help'
@@ -47,7 +46,6 @@ node('docker') {
 
     stage ('Build images') {
         baseImageExist = doesBaseImageExist(major_version)
-        /*
         if ( baseImageExist ) {
             echo "Base image exists, using that"
             withEnv(["DOCKER_BUILDKIT=1"]) {
@@ -74,6 +72,5 @@ node('docker') {
                 pushImage("${gcpProject}/bw-lucene-solr:${version}", version)
             }
         }
-        */
     }
 }

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -1,0 +1,44 @@
+FROM debian:stretch
+
+RUN echo "deb http://http.debian.net/debian stretch-backports main" | \
+     tee --append /etc/apt/sources.list.d/stretch-backports.list > /dev/null && \ 
+     apt-get update -y && \
+     apt-get install -y \
+     wget \
+     curl \
+     ruby \
+     ruby-dev \
+     rubygems \
+     build-essential \
+     git-core && \
+     apt-get install -y -t stretch-backports openjdk-8-jdk && \
+     update-java-alternatives -s java-1.8.0-openjdk-amd64 && \
+     apt-get upgrade -y
+
+RUN export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
+
+RUN gem install fpm
+RUN fpm --version
+
+#Installing Apache Ant
+RUN wget http://archive.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.tar.gz
+RUN wget https://www.apache.org/dist/ant/KEYS
+RUN wget https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.tar.gz.asc
+
+#Verify download signature
+RUN gpg --import KEYS
+RUN gpg --verify apache-ant-1.10.5-bin.tar.gz.asc
+
+#Unpack
+RUN tar xvfvz apache-ant-1.10.5-bin.tar.gz
+
+RUN mv apache-ant-1.10.5 /opt/ant
+RUN echo ANT_HOME=/opt/ant >> /etc/environment
+RUN ln -s /opt/ant/bin/ant /usr/bin/ant
+
+#Installing Apache Ivy from git repository
+RUN git clone https://git-wip-us.apache.org/repos/asf/ant-ivy.git
+WORKDIR /ant-ivy
+RUN ant jar
+WORKDIR /ant-ivy/build/artifact/jars
+RUN scp ivy.jar /opt/ant/lib

--- a/versions.json
+++ b/versions.json
@@ -1,0 +1,4 @@
+{
+  "version": "7.7.2",
+  "major_version": "7"
+}

--- a/versions.json
+++ b/versions.json
@@ -1,4 +1,4 @@
 {
   "version": "7.7.2",
-  "major_version": "7"
+  "ant_version": "1.10.5"
 }


### PR DESCRIPTION
This adds jenkins support for the solr repo, and will do the following:

1. Push an ant-based docker image to our gcp repo _(under `ant-base`)_
2. Push a solr based docker image to our gcp repo _(under `bw-lucene-solr`)_

This was mainly done to make the solr prometheus exporter dockerising significantly easier.

The ant-base image doesn't need to change much, only for each major version of solr, because of this, there is a check to see if there is an image for that major version of solr in our gcp already, if there is, it'll use that, otherwise create one.

Version numbering is maintained in a `versions.json` file, I originally had some regex stuff to not need a `versions.json` file, but then it could get complicated with the relying of branch naming convention.