### PR TITLE
Fix termfreqfreq for non-distributed searches

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/facet/TermFrequencyCounter.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/TermFrequencyCounter.java
@@ -1,6 +1,7 @@
 package org.apache.solr.search.facet;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -35,5 +36,13 @@ public class TermFrequencyCounter {
     serialized.forEach((value, freq) -> counters.merge(value, freq, Integer::sum));
 
     return this;
+  }
+
+  public Map<Integer, Integer> toFrequencyOfFrequencies() {
+    Map<Integer, Integer> map = new LinkedHashMap<>();
+
+    counters.forEach((value, freq) -> map.merge(freq, 1, Integer::sum));
+
+    return map;
   }
 }

--- a/solr/core/src/java/org/apache/solr/search/facet/TermFrequencyOfFrequenciesAgg.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/TermFrequencyOfFrequenciesAgg.java
@@ -62,12 +62,7 @@ public class TermFrequencyOfFrequenciesAgg extends SimpleAggValueSource {
 
     @Override
     public Object getMergedResult() {
-      Map<Integer, Integer> map = new LinkedHashMap<>();
-
-      result.getCounters()
-        .forEach((value, freq) -> map.merge(freq, 1, Integer::sum));
-
-      return map;
+      return result.toFrequencyOfFrequencies();
     }
   }
 }

--- a/solr/core/src/java/org/apache/solr/search/facet/TermFrequencySlotAcc.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/TermFrequencySlotAcc.java
@@ -33,10 +33,18 @@ public class TermFrequencySlotAcc extends FuncSlotAcc {
 
   @Override
   public Object getValue(int slotNum) {
-    if (result[slotNum] != null) {
-      return result[slotNum].serialize(termLimit);
+    if (fcontext.isShard()) {
+      if (result[slotNum] != null) {
+        return result[slotNum].serialize(termLimit);
+      } else {
+        return Collections.emptyList();
+      }
     } else {
-      return Collections.emptyList();
+      if (result[slotNum] != null) {
+        return result[slotNum].toFrequencyOfFrequencies();
+      } else {
+        return Collections.emptyMap();
+      }
     }
   }
 


### PR DESCRIPTION
We were relying on the FacetMerger to finalise the termfreqfreq results
(converting the raw frequencies into the frequency-of-frequencies), but
this is only invoked during distributed search - e.g. it will be skipped
when we are only searching a single collection/shard.

To address this, we need to modify the SlotAcc to check whether we are
in distributed mode before serializing each shard's results - when there
is only a single shard, we serialize the results into their final form,
rather than the intermediate form required for distributed search.