### PR TITLE
DSTORE-1475 out of order compliance operations

### DIFF
--- a/solr/core/src/java/org/apache/solr/update/processor/ConditionalUpsertProcessorFactory.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/ConditionalUpsertProcessorFactory.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.update.processor;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.solr.common.SolrException;
+import org.apache.solr.common.SolrInputDocument;
+import org.apache.solr.common.util.NamedList;
+import org.apache.solr.core.SolrCore;
+import org.apache.solr.handler.component.RealTimeGetComponent;
+import org.apache.solr.request.SolrQueryRequest;
+import org.apache.solr.response.SolrQueryResponse;
+import org.apache.solr.update.AddUpdateCommand;
+import org.apache.solr.update.UpdateCommand;
+import org.apache.solr.util.plugin.SolrCoreAware;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.solr.common.SolrException.ErrorCode.SERVER_ERROR;
+import static org.apache.solr.update.processor.DistributingUpdateProcessorFactory.DISTRIB_UPDATE_PARAM;
+
+public class ConditionalUpsertProcessorFactory extends UpdateRequestProcessorFactory implements SolrCoreAware, UpdateRequestProcessorFactory.RunAlways {
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  private final List<UpsertCondition> conditions = new ArrayList<>();
+
+  @Override
+  public void init(NamedList args)  {
+    for (Map.Entry<String, ?> entry: (NamedList<?>)args) {
+      String name = entry.getKey();
+      Object tmp = entry.getValue();
+      if (tmp instanceof NamedList) {
+        NamedList<String> condition = (NamedList<String>)tmp;
+        conditions.add(UpsertCondition.parse(name, condition));
+      }
+      // TODO errors etc
+    }
+    super.init(args);
+  }
+
+  @Override
+  public ConditionalUpsertUpdateProcessor getInstance(SolrQueryRequest req,
+                                                      SolrQueryResponse rsp,
+                                                      UpdateRequestProcessor next) {
+    return new ConditionalUpsertUpdateProcessor(req, next, conditions);
+  }
+
+  @Override
+  public void inform(SolrCore core) {
+    if (core.getUpdateHandler().getUpdateLog() == null) {
+      throw new SolrException(SERVER_ERROR, "updateLog must be enabled.");
+    }
+
+    if (core.getLatestSchema().getUniqueKeyField() == null) {
+      throw new SolrException(SERVER_ERROR, "schema must have uniqueKey defined.");
+    }
+  }
+
+  static class ConditionalUpsertUpdateProcessor extends UpdateRequestProcessor {
+    private final SolrCore core;
+
+    private DistributedUpdateProcessor distribProc;  // the distributed update processor following us
+    private DistributedUpdateProcessor.DistribPhase phase;
+    private final List<UpsertCondition> conditions;
+
+    ConditionalUpsertUpdateProcessor(SolrQueryRequest req,
+                                     UpdateRequestProcessor next,
+                                     List<UpsertCondition> conditions) {
+      super(next);
+      this.core = req.getCore();
+      this.conditions = conditions;
+
+      for (UpdateRequestProcessor proc = next ;proc != null; proc = proc.next) {
+        if (proc instanceof DistributedUpdateProcessor) {
+          distribProc = (DistributedUpdateProcessor)proc;
+          break;
+        }
+      }
+
+      if (distribProc == null) {
+        throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, "DistributedUpdateProcessor must follow ConditionalUpsertProcessor");
+      }
+
+      phase = DistributedUpdateProcessor.DistribPhase.parseParam(req.getParams().get(DISTRIB_UPDATE_PARAM));
+    }
+
+    boolean isLeader(UpdateCommand cmd) {
+      if ((cmd.getFlags() & (UpdateCommand.REPLAY | UpdateCommand.PEER_SYNC)) != 0) {
+        return false;
+      }
+      if (phase == DistributedUpdateProcessor.DistribPhase.FROMLEADER) {
+        return false;
+      }
+      return distribProc.isLeader(cmd);
+    }
+
+    @Override
+    public void processAdd(AddUpdateCommand cmd) throws IOException {
+      BytesRef indexedDocId = cmd.getIndexedId();
+
+      if (!conditions.isEmpty() && isLeader(cmd)) {
+        SolrInputDocument newDoc = cmd.getSolrInputDocument();
+        SolrInputDocument oldDoc = RealTimeGetComponent.getInputDocument(core, indexedDocId);
+        if (oldDoc != null) {
+          for (UpsertCondition condition: conditions) {
+            if (condition.matches(oldDoc, newDoc)) {
+              log.info("Condition {} matched, taking action", condition.getName());
+              if (condition.isSkip()) {
+                log.info("Condition {} matched - skipping insert", condition.getName());
+                return;
+              }
+              condition.copyOldDocFields(oldDoc, newDoc);
+              break;
+            }
+          }
+        }
+      }
+      super.processAdd(cmd);
+    }
+  }
+}

--- a/solr/core/src/java/org/apache/solr/update/processor/ConditionalUpsertProcessorFactory.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/ConditionalUpsertProcessorFactory.java
@@ -129,6 +129,11 @@ public class ConditionalUpsertProcessorFactory extends UpdateRequestProcessorFac
                 log.info("Condition {} matched - skipping insert", condition.getName());
                 return;
               }
+              if (condition.isInsert()) {
+                log.info("Condition {} matched - will insert", condition.getName());
+                break;
+              }
+
               condition.copyOldDocFields(oldDoc, newDoc);
               break;
             }

--- a/solr/core/src/java/org/apache/solr/update/processor/UpsertCondition.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/UpsertCondition.java
@@ -76,13 +76,13 @@ class UpsertCondition {
   static boolean shouldInsertOrUpsert(List<UpsertCondition> conditions, SolrInputDocument oldDoc, SolrInputDocument newDoc) {
     for (UpsertCondition condition: conditions) {
       if (condition.matches(oldDoc, newDoc)) {
-        log.info("Condition {} matched, taking action", condition.getName());
+        log.debug("Condition {} matched, taking action", condition.getName());
         if (condition.isSkip()) {
-          log.info("Condition {} matched - skipping insert", condition.getName());
+          log.debug("Condition {} matched - skipping insert", condition.getName());
           return false;
         }
         if (condition.isInsert()) {
-          log.info("Condition {} matched - will insert", condition.getName());
+          log.debug("Condition {} matched - will insert", condition.getName());
           break;
         }
 

--- a/solr/core/src/java/org/apache/solr/update/processor/UpsertCondition.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/UpsertCondition.java
@@ -303,6 +303,9 @@ class UpsertCondition {
 
     void run(SolrInputDocument oldDoc, SolrInputDocument newDoc) {
       if (type == ActionType.UPSERT || type == ActionType.RETAIN) {
+        if (oldDoc == null) {
+          return;
+        }
         Collection<String> fieldsToCopy;
         if (ALL_FIELDS.equals(fields)) {
           fieldsToCopy = oldDoc.keySet();

--- a/solr/core/src/java/org/apache/solr/update/processor/UpsertCondition.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/UpsertCondition.java
@@ -252,7 +252,7 @@ class UpsertCondition {
           if ("*".equals(value)) {
             docPredicate = forField(field, Objects::nonNull);
           } else {
-            docPredicate = forField(field, value::equals);
+            docPredicate = forField(field, stringlyEquals(value));
           }
         }
         return new FieldRule(occur, docGetter, docPredicate);
@@ -267,6 +267,18 @@ class UpsertCondition {
     boolean matches(Docs docs) {
       SolrInputDocument doc = docGetter.apply(docs);
       return docPredicate.test(doc);
+    }
+
+    private static Predicate<Object> stringlyEquals(String value) {
+      return fieldValue -> {
+        if (fieldValue == null) {
+          return false;
+        }
+        if (!(fieldValue instanceof String)) {
+          return value.equals(fieldValue.toString());
+        }
+        return value.equals(fieldValue);
+      };
     }
 
     private static Predicate<SolrInputDocument> forField(String field, Predicate<Object> fieldPredicate) {

--- a/solr/core/src/java/org/apache/solr/update/processor/UpsertCondition.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/UpsertCondition.java
@@ -270,7 +270,15 @@ class UpsertCondition {
     }
 
     private static Predicate<SolrInputDocument> forField(String field, Predicate<Object> fieldPredicate) {
-      return doc -> doc != null && fieldPredicate.test(doc.getFieldValue(field));
+      return doc -> {
+        if (doc != null) {
+          Collection<Object> values = doc.getFieldValues(field);
+          if (values != null) {
+            return values.stream().anyMatch(fieldPredicate);
+          }
+        }
+        return false;
+      };
     }
   }
 }

--- a/solr/core/src/java/org/apache/solr/update/processor/UpsertCondition.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/UpsertCondition.java
@@ -1,0 +1,205 @@
+package org.apache.solr.update.processor;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.lucene.search.BooleanClause;
+import org.apache.solr.common.SolrException;
+import org.apache.solr.common.SolrInputDocument;
+import org.apache.solr.common.SolrInputField;
+import org.apache.solr.common.util.NamedList;
+
+import static org.apache.solr.common.SolrException.ErrorCode.SERVER_ERROR;
+
+class UpsertCondition {
+  private static final Pattern ACTION_PATTERN = Pattern.compile("^(skip)|(upsert):(\\*|[\\w,]+)$");
+  private static final List<String> ALL_FIELDS = Collections.singletonList("*");
+
+  private final String name;
+  private final List<FieldRule> rules;
+  private final boolean skip;
+  private final List<String> upsertFields;
+
+  UpsertCondition(String name, boolean skip, List<String> upsertFields, List<FieldRule> rules) {
+    this.name = name;
+    this.skip = skip;
+    this.upsertFields = upsertFields;
+    this.rules = rules;
+  }
+
+  static UpsertCondition parse(String name, NamedList<String> args) {
+    List<FieldRule> rules = new ArrayList<>();
+    boolean skip = false;
+    List<String> upsertFields = null;
+    for (Map.Entry<String, String> entry: args) {
+      String key = entry.getKey();
+      if ("action".equals(key)) {
+        String action = entry.getValue();
+        Matcher m = ACTION_PATTERN.matcher(action);
+        if (!m.matches()) {
+          throw new SolrException(SERVER_ERROR, "'" + action + "' not a valid action");
+        }
+        if (m.group(1) != null) {
+          skip = true;
+          upsertFields = null;
+        } else {
+          skip = false;
+          String fields = m.group(3);
+          upsertFields = Arrays.asList(fields.split(","));
+        }
+      } else {
+        BooleanClause.Occur occur;
+        try {
+          occur = BooleanClause.Occur.valueOf(key.toUpperCase(Locale.ROOT));
+        } catch(IllegalArgumentException e) {
+          throw new SolrException(SERVER_ERROR, "'" + key + "' not a valid occurence value");
+        }
+        String value = entry.getValue();
+        rules.add(FieldRule.parse(occur, value));
+      }
+    }
+    if (!skip && upsertFields == null) {
+      throw new SolrException(SERVER_ERROR, "no action defined for condition: " + name);
+    }
+    if (rules.isEmpty()) {
+      throw new SolrException(SERVER_ERROR, "no rules specified for condition: " + name);
+    }
+    return new UpsertCondition(name, skip, upsertFields, rules);
+  }
+
+  String getName() {
+    return name;
+  }
+
+  boolean isSkip() {
+    return skip;
+  }
+
+  void copyOldDocFields(SolrInputDocument oldDoc, SolrInputDocument newDoc) {
+    if (skip) {
+      throw new IllegalStateException("Cannot copy old doc fields when skipping");
+    }
+    Collection<String> fieldsToCopy;
+    if (ALL_FIELDS.equals(upsertFields)) {
+      fieldsToCopy = oldDoc.keySet();
+    } else {
+      fieldsToCopy = upsertFields;
+    }
+    fieldsToCopy.forEach(field -> {
+      if (!newDoc.containsKey(field)) {
+        SolrInputField inputField = oldDoc.getField(field);
+        newDoc.put(field, inputField);
+      }
+    });
+  }
+
+  boolean matches(SolrInputDocument oldDoc, SolrInputDocument newDoc) {
+    Docs docs = new Docs(oldDoc, newDoc);
+    boolean atLeastOneMatched = false;
+    for (FieldRule rule: rules) {
+      boolean ruleMatched = rule.matches(docs);
+      switch(rule.getOccur()) {
+        case MUST:
+          if (!ruleMatched) {
+            return false;
+          }
+          atLeastOneMatched = true;
+          break;
+        case MUST_NOT:
+          if (ruleMatched) {
+            return false;
+          }
+          atLeastOneMatched = true;
+          break;
+        default:
+          atLeastOneMatched = ruleMatched || atLeastOneMatched;
+          break;
+      }
+    }
+    return atLeastOneMatched;
+  }
+
+  private static class Docs {
+    private final SolrInputDocument oldDoc;
+    private final SolrInputDocument newDoc;
+
+    Docs(SolrInputDocument oldDoc, SolrInputDocument newDoc) {
+      this.oldDoc = oldDoc;
+      this.newDoc = newDoc;
+    }
+
+    SolrInputDocument getOldDoc() {
+      return oldDoc;
+    }
+
+    SolrInputDocument getNewDoc() {
+      return newDoc;
+    }
+  }
+
+  private static class FieldRule {
+    private static final Pattern RULE_CONDITION_PATTERN = Pattern.compile("^(OLD|NEW)\\.(\\w+):(\\w+)$");
+
+    private final BooleanClause.Occur occur;
+    private final Function<Docs, SolrInputDocument> docGetter;
+    private final String field;
+    private final String value;
+
+    private FieldRule(BooleanClause.Occur occur, Function<Docs, SolrInputDocument> docGetter, String field, String value) {
+      this.occur = occur;
+      this.docGetter = docGetter;
+      this.field = field;
+      this.value = value;
+    }
+
+    static FieldRule parse(BooleanClause.Occur occur, String condition) {
+      Matcher m = RULE_CONDITION_PATTERN.matcher(condition);
+      if (m.matches()) {
+        String doc = m.group(1);
+        String field = m.group(2);
+        String value = m.group(3);
+        Function<Docs, SolrInputDocument> docGetter;
+        if (doc.equalsIgnoreCase("OLD")) {
+          docGetter = Docs::getOldDoc;
+        } else {
+          docGetter = Docs::getNewDoc;
+        }
+        return new FieldRule(occur, docGetter, field, value);
+      }
+      throw new SolrException(SERVER_ERROR, "'" + condition + "' not a valid condition for rule");
+    }
+
+    BooleanClause.Occur getOccur() {
+      return occur;
+    }
+
+    boolean matches(Docs docs) {
+      SolrInputDocument doc = docGetter.apply(docs);
+      return value.equals(doc.getFieldValue(field));
+    }
+  }
+}

--- a/solr/core/src/test/org/apache/solr/update/processor/UpsertConditionTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/UpsertConditionTest.java
@@ -1,18 +1,18 @@
 package org.apache.solr.update.processor;
 
+import java.util.List;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableListMultimap;
-import com.google.common.collect.ListMultimap;
-import java.util.List;
-
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ListMultimap;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.util.NamedList;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
@@ -94,6 +94,15 @@ public class UpsertConditionTest {
     UpsertCondition.parse("bad-action", args);
   }
 
+  @Test(expected = SolrException.class)
+  public void givenBadUpsert_whenParsingCondition() {
+    NamedList<String> args = namedList(ImmutableListMultimap.of(
+        "must", "OLD.field:value",
+        "action", "upsert:%^&"
+    ));
+    UpsertCondition.parse("bad-action", args);
+  }
+
   @Test
   public void givenNoOldDoc_whenMatching() {
     NamedList<String> args = new NamedList<>(ImmutableMap.of(
@@ -103,8 +112,6 @@ public class UpsertConditionTest {
 
     UpsertCondition condition = UpsertCondition.parse("skip-it", args);
 
-    assertThat(condition.isSkip(), is(true));
-    assertThat(condition.isInsert(), is(false));
     assertThat(condition.getName(), is("skip-it"));
 
     SolrInputDocument oldDoc = null;
@@ -122,8 +129,6 @@ public class UpsertConditionTest {
 
     UpsertCondition condition = UpsertCondition.parse("skip-it", args);
 
-    assertThat(condition.isSkip(), is(true));
-    assertThat(condition.isInsert(), is(false));
     assertThat(condition.getName(), is("skip-it"));
 
     SolrInputDocument oldDoc = new SolrInputDocument();
@@ -150,8 +155,6 @@ public class UpsertConditionTest {
 
     UpsertCondition condition = UpsertCondition.parse("skip-it", args);
 
-    assertThat(condition.isSkip(), is(true));
-    assertThat(condition.isInsert(), is(false));
     assertThat(condition.getName(), is("skip-it"));
 
     SolrInputDocument oldDoc = new SolrInputDocument();
@@ -175,8 +178,6 @@ public class UpsertConditionTest {
 
     UpsertCondition condition = UpsertCondition.parse("skip-it", args);
 
-    assertThat(condition.isSkip(), is(true));
-    assertThat(condition.isInsert(), is(false));
     assertThat(condition.getName(), is("skip-it"));
 
     SolrInputDocument oldDoc = new SolrInputDocument();
@@ -200,8 +201,6 @@ public class UpsertConditionTest {
 
     UpsertCondition condition = UpsertCondition.parse("skip-it", args);
 
-    assertThat(condition.isSkip(), is(true));
-    assertThat(condition.isInsert(), is(false));
     assertThat(condition.getName(), is("skip-it"));
 
     SolrInputDocument oldDoc = new SolrInputDocument();
@@ -225,8 +224,6 @@ public class UpsertConditionTest {
 
     UpsertCondition condition = UpsertCondition.parse("skip-it", args);
 
-    assertThat(condition.isSkip(), is(true));
-    assertThat(condition.isInsert(), is(false));
     assertThat(condition.getName(), is("skip-it"));
 
     SolrInputDocument oldDoc = new SolrInputDocument();
@@ -250,8 +247,6 @@ public class UpsertConditionTest {
 
     UpsertCondition condition = UpsertCondition.parse("skip-it", args);
 
-    assertThat(condition.isSkip(), is(true));
-    assertThat(condition.isInsert(), is(false));
     assertThat(condition.getName(), is("skip-it"));
 
     SolrInputDocument oldDoc = new SolrInputDocument();
@@ -275,8 +270,6 @@ public class UpsertConditionTest {
 
     UpsertCondition condition = UpsertCondition.parse("skip-it", args);
 
-    assertThat(condition.isSkip(), is(true));
-    assertThat(condition.isInsert(), is(false));
     assertThat(condition.getName(), is("skip-it"));
 
     SolrInputDocument oldDoc = new SolrInputDocument();
@@ -300,8 +293,6 @@ public class UpsertConditionTest {
 
     UpsertCondition condition = UpsertCondition.parse("skip-it", args);
 
-    assertThat(condition.isSkip(), is(true));
-    assertThat(condition.isInsert(), is(false));
     assertThat(condition.getName(), is("skip-it"));
 
     SolrInputDocument oldDoc = new SolrInputDocument();
@@ -334,8 +325,6 @@ public class UpsertConditionTest {
 
     UpsertCondition condition = UpsertCondition.parse("skip-it", args);
 
-    assertThat(condition.isSkip(), is(true));
-    assertThat(condition.isInsert(), is(false));
     assertThat(condition.getName(), is("skip-it"));
 
     SolrInputDocument oldDoc = new SolrInputDocument();
@@ -371,8 +360,6 @@ public class UpsertConditionTest {
 
     UpsertCondition condition = UpsertCondition.parse("skip-it", args);
 
-    assertThat(condition.isSkip(), is(true));
-    assertThat(condition.isInsert(), is(false));
     assertThat(condition.getName(), is("skip-it"));
 
     SolrInputDocument oldDoc = new SolrInputDocument();
@@ -396,8 +383,8 @@ public class UpsertConditionTest {
     assertTrue(condition.matches(oldDoc, newDoc));
   }
 
-  @Test(expected = IllegalStateException.class)
-  public void givenSkipAction_whenCopyingOldFields() {
+  @Test
+  public void givenSkipAction_whenRunning() {
     NamedList<String> args = namedList(ImmutableListMultimap.of(
         "should", "OLD.field:value",
         "action", "skip"
@@ -405,18 +392,18 @@ public class UpsertConditionTest {
 
     UpsertCondition condition = UpsertCondition.parse("skip-it", args);
 
-    assertThat(condition.isSkip(), is(true));
-    assertThat(condition.isInsert(), is(false));
     assertThat(condition.getName(), is("skip-it"));
 
     SolrInputDocument oldDoc = new SolrInputDocument();
     SolrInputDocument newDoc = new SolrInputDocument();
 
-    condition.copyOldDocFields(oldDoc, newDoc);
+    assertThat(condition.run(oldDoc, newDoc), is(UpsertCondition.ActionType.SKIP));
+    assertThat(oldDoc.isEmpty(), is(true));
+    assertThat(newDoc.isEmpty(), is(true));
   }
 
-  @Test(expected = IllegalStateException.class)
-  public void givenInsertAction_whenCopyingOldFields() {
+  @Test
+  public void givenInsertAction_whenRunning() {
     NamedList<String> args = namedList(ImmutableListMultimap.of(
         "should", "OLD.field:value",
         "action", "insert"
@@ -424,43 +411,18 @@ public class UpsertConditionTest {
 
     UpsertCondition condition = UpsertCondition.parse("insert-it", args);
 
-    assertThat(condition.isSkip(), is(false));
-    assertThat(condition.isInsert(), is(true));
     assertThat(condition.getName(), is("insert-it"));
 
     SolrInputDocument oldDoc = new SolrInputDocument();
     SolrInputDocument newDoc = new SolrInputDocument();
 
-    condition.copyOldDocFields(oldDoc, newDoc);
+    assertThat(condition.run(oldDoc, newDoc), is(UpsertCondition.ActionType.INSERT));
+    assertThat(oldDoc.isEmpty(), is(true));
+    assertThat(newDoc.isEmpty(), is(true));
   }
 
   @Test
-  public void givenInsert_whenMatching() {
-    NamedList<String> args = namedList(ImmutableListMultimap.of(
-        "must", "OLD.field:value",
-        "action", "insert"
-    ));
-
-    UpsertCondition condition = UpsertCondition.parse("insert-it", args);
-
-    assertThat(condition.isSkip(), is(false));
-    assertThat(condition.isInsert(), is(true));
-    assertThat(condition.getName(), is("insert-it"));
-
-    SolrInputDocument oldDoc = new SolrInputDocument();
-    SolrInputDocument newDoc = new SolrInputDocument();
-
-    assertFalse(condition.matches(oldDoc, newDoc));
-
-    oldDoc.setField("field", "value");
-    assertTrue(condition.matches(oldDoc, newDoc));
-
-    oldDoc.setField("field", "not-value");
-    assertFalse(condition.matches(oldDoc, newDoc));
-  }
-
-  @Test
-  public void givenUpsertForSpecificFields_whenCopyingOldFields() {
+  public void givenUpsertForSpecificFields_whenRunning() {
     NamedList<String> args = namedList(ImmutableListMultimap.of(
         "must", "OLD.field:value",
         "action", "upsert:field,other_field"
@@ -468,8 +430,6 @@ public class UpsertConditionTest {
 
     UpsertCondition condition = UpsertCondition.parse("upsert", args);
 
-    assertThat(condition.isSkip(), is(false));
-    assertThat(condition.isInsert(), is(false));
     assertThat(condition.getName(), is("upsert"));
 
     SolrInputDocument oldDoc = new SolrInputDocument();
@@ -478,7 +438,7 @@ public class UpsertConditionTest {
     oldDoc.setField("other_field", "old-value");
     oldDoc.setField("not-copied", "not-copied");
 
-    condition.copyOldDocFields(oldDoc, newDoc);
+    assertThat(condition.run(oldDoc, newDoc), is(UpsertCondition.ActionType.UPSERT));
 
     assertThat(newDoc.getFieldValue("field"), is("value"));
     assertThat(newDoc.getFieldValue("other_field"), is("old-value"));
@@ -487,7 +447,7 @@ public class UpsertConditionTest {
     newDoc = new SolrInputDocument();
     newDoc.setField("field", "left-alone");
 
-    condition.copyOldDocFields(oldDoc, newDoc);
+    assertThat(condition.run(oldDoc, newDoc), is(UpsertCondition.ActionType.UPSERT));
 
     assertThat(newDoc.getFieldValue("field"), is("left-alone"));
     assertThat(newDoc.getFieldValue("other_field"), is("old-value"));
@@ -495,7 +455,7 @@ public class UpsertConditionTest {
   }
 
   @Test
-  public void givenRetainForSpecificFields_whenCopyingOldFields() {
+  public void givenRetainForSpecificFields_whenRunning() {
     NamedList<String> args = namedList(ImmutableListMultimap.of(
         "must", "OLD.field:value",
         "action", "retain:field,other_field"
@@ -503,8 +463,6 @@ public class UpsertConditionTest {
 
     UpsertCondition condition = UpsertCondition.parse("retain", args);
 
-    assertThat(condition.isSkip(), is(false));
-    assertThat(condition.isInsert(), is(false));
     assertThat(condition.getName(), is("retain"));
 
     SolrInputDocument oldDoc = new SolrInputDocument();
@@ -513,7 +471,7 @@ public class UpsertConditionTest {
     oldDoc.setField("other_field", "old-value2");
     oldDoc.setField("not-copied", "not-copied");
 
-    condition.copyOldDocFields(oldDoc, newDoc);
+    assertThat(condition.run(oldDoc, newDoc), is(UpsertCondition.ActionType.RETAIN));
 
     assertThat(newDoc.getFieldValue("field"), is("old-value1"));
     assertThat(newDoc.getFieldValue("other_field"), is("old-value2"));
@@ -522,7 +480,7 @@ public class UpsertConditionTest {
     newDoc = new SolrInputDocument();
     newDoc.setField("field", "should-be-overridden");
 
-    condition.copyOldDocFields(oldDoc, newDoc);
+    assertThat(condition.run(oldDoc, newDoc), is(UpsertCondition.ActionType.RETAIN));
 
     assertThat(newDoc.getFieldValue("field"), is("old-value1"));
     assertThat(newDoc.getFieldValue("other_field"), is("old-value2"));
@@ -530,7 +488,7 @@ public class UpsertConditionTest {
   }
 
   @Test
-  public void givenUpsertForAllFields_whenCopyingOldFields() {
+  public void givenUpsertForAllFields_whenRunning() {
     NamedList<String> args = namedList(ImmutableListMultimap.of(
         "must", "OLD.field:value",
         "action", "upsert:*"
@@ -538,8 +496,6 @@ public class UpsertConditionTest {
 
     UpsertCondition condition = UpsertCondition.parse("upsert", args);
 
-    assertThat(condition.isSkip(), is(false));
-    assertThat(condition.isInsert(), is(false));
     assertThat(condition.getName(), is("upsert"));
 
     SolrInputDocument oldDoc = new SolrInputDocument();
@@ -548,7 +504,7 @@ public class UpsertConditionTest {
     oldDoc.setField("other_field", "old-value");
     oldDoc.setField("also-copied", "also-copied");
 
-    condition.copyOldDocFields(oldDoc, newDoc);
+    assertThat(condition.run(oldDoc, newDoc), is(UpsertCondition.ActionType.UPSERT));
 
     assertThat(newDoc.getFieldValue("field"), is("value"));
     assertThat(newDoc.getFieldValue("other_field"), is("old-value"));
@@ -557,7 +513,7 @@ public class UpsertConditionTest {
     newDoc = new SolrInputDocument();
     newDoc.setField("field", "left-alone");
 
-    condition.copyOldDocFields(oldDoc, newDoc);
+    assertThat(condition.run(oldDoc, newDoc), is(UpsertCondition.ActionType.UPSERT));
 
     assertThat(newDoc.getFieldValue("field"), is("left-alone"));
     assertThat(newDoc.getFieldValue("other_field"), is("old-value"));
@@ -628,6 +584,26 @@ public class UpsertConditionTest {
   }
 
   @Test
+  public void givenExistingSoftDeleteAndMetrics_whenCheckingShouldInsertOrUpsert() {
+    List<UpsertCondition> conditions = givenMultipleConditions();
+
+    SolrInputDocument oldDoc = new SolrInputDocument();
+    SolrInputDocument newDoc = new SolrInputDocument();
+
+    oldDoc.setField("compliance_reason", "soft_delete");
+    oldDoc.setField("metric1", "kept-from-old1");
+    oldDoc.setField("metric2", "kept-from-old2");
+    oldDoc.setField("metric3", "not-kept-from-old");
+    newDoc.setField("new_field", "kept-from-new");
+
+    assertThat(UpsertCondition.shouldInsertOrUpsert(conditions, oldDoc, newDoc), is(true));
+    assertThat(newDoc.getFieldValue("compliance_reason"), is("soft_delete"));
+    assertThat(newDoc.getFieldValue("metric1"), is("kept-from-old1"));
+    assertThat(newDoc.getFieldValue("metric2"), is("kept-from-old2"));
+    assertThat(newDoc.getFieldValue("metric3"), nullValue());
+  }
+
+  @Test
   public void givenForceInsert_whenCheckingShouldInsertOrUpsert() {
     List<UpsertCondition> conditions = givenMultipleConditions();
 
@@ -666,6 +642,15 @@ public class UpsertConditionTest {
   }
 
   private List<UpsertCondition> givenMultipleConditions() {
+    // this roughly represents some sort of "compliance" scenario
+    // where we want to delete and/or redact documents in a variety
+    // of ways
+    // also some other rules are in here around updating metrics etc
+    // just so we can test how things interact
+    // this might represent a system where we receive deletes + updates
+    // requests for documents, but don't have the full document to hand (elsewhere)
+    // or we expect to receive delete + update requests _prior_ to receiving the
+    // actual documents (at least sometimes)
     NamedList<?> args = namedList(ImmutableListMultimap.<String, NamedList<String>>builder()
         .put("forceInsert", namedList(ImmutableListMultimap.of(
             "must", "NEW.force_insert:true",
@@ -675,18 +660,21 @@ public class UpsertConditionTest {
             "must", "OLD.compliance_reason:delete",
             "action", "skip"
         )))
-        .put("existingSoftDeletes", namedList(ImmutableListMultimap.of(
-            "must", "OLD.compliance_reason:soft_delete",
-            "action", "upsert:compliance_reason"
-        )))
-        .put("newSoftDeletes", namedList(ImmutableListMultimap.of(
-            "must", "NEW.compliance_reason:soft_delete",
-            "action", "upsert:*"
-        )))
+        // updating metrics will fall through as it has no insert
         .put("existingMetrics", namedList(ImmutableListMultimap.of(
             "should", "OLD.metric1:*",
             "should", "OLD.metric2:*",
             "action", "upsert:metric1,metric2"
+        )))
+        .put("existingSoftDeletes", namedList(ImmutableListMultimap.of(
+            "must", "OLD.compliance_reason:soft_delete",
+            "action", "upsert:compliance_reason",
+            "action", "insert"
+        )))
+        .put("newSoftDeletes", namedList(ImmutableListMultimap.of(
+            "must", "NEW.compliance_reason:soft_delete",
+            "action", "upsert:*",
+            "action", "insert"
         )))
         .put("skipIfNotExists", namedList(ImmutableListMultimap.of(
             "must_not", "OLD.*",

--- a/solr/core/src/test/org/apache/solr/update/processor/UpsertConditionTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/UpsertConditionTest.java
@@ -153,6 +153,29 @@ public class UpsertConditionTest {
   }
 
   @Test
+  public void givenSingleShouldAnyValueClause_whenMatching() {
+    NamedList<String> args = new NamedList<>();
+    args.add("should", "OLD.field:*");
+    args.add("action", "skip");
+
+    UpsertCondition condition = UpsertCondition.parse("skip-it", args);
+
+    assertThat(condition.isSkip(), is(true));
+    assertThat(condition.getName(), is("skip-it"));
+
+    SolrInputDocument oldDoc = new SolrInputDocument();
+    SolrInputDocument newDoc = new SolrInputDocument();
+
+    assertFalse(condition.matches(oldDoc, newDoc));
+
+    oldDoc.setField("field", "value");
+    assertTrue(condition.matches(oldDoc, newDoc));
+
+    oldDoc.setField("field", "not-value");
+    assertTrue(condition.matches(oldDoc, newDoc));
+  }
+
+  @Test
   public void givenMultipleMustClauses_whenMatching() {
     NamedList<String> args = new NamedList<>();
     args.add("must", "OLD.field1:value1");

--- a/solr/core/src/test/org/apache/solr/update/processor/UpsertConditionTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/UpsertConditionTest.java
@@ -1,0 +1,337 @@
+package org.apache.solr.update.processor;
+
+import org.apache.solr.common.SolrException;
+import org.apache.solr.common.SolrInputDocument;
+import org.apache.solr.common.util.NamedList;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+public class UpsertConditionTest {
+
+  @Test(expected = SolrException.class)
+  public void givenNoAction_whenParsingCondition() {
+    NamedList<String> args = new NamedList<>();
+    args.add("must", "OLD.field:value");
+    UpsertCondition.parse("no-action", args);
+  }
+
+  @Test(expected = SolrException.class)
+  public void givenInvalidMatchOccurrence_whenParsingCondition() {
+    NamedList<String> args = new NamedList<>();
+    args.add("maybe_might", "OLD.field:value");
+    args.add("action", "skip");
+    UpsertCondition.parse("bad-occurrence", args);
+  }
+
+  @Test(expected = SolrException.class)
+  public void givenNoRules_whenParsingCondition() {
+    NamedList<String> args = new NamedList<>();
+    args.add("action", "skip");
+    UpsertCondition.parse("no-rules", args);
+  }
+
+  @Test(expected = SolrException.class)
+  public void givenBadRuleDocPart_whenParsingCondition() {
+    NamedList<String> args = new NamedList<>();
+    args.add("must", "YOUNG.field:value");
+    args.add("action", "skip");
+    UpsertCondition.parse("bad-rule", args);
+  }
+
+  @Test(expected = SolrException.class)
+  public void givenNoDocPart_whenParsingCondition() {
+    NamedList<String> args = new NamedList<>();
+    args.add("must", "field:value");
+    args.add("action", "skip");
+    UpsertCondition.parse("bad-rule", args);
+  }
+
+  @Test(expected = SolrException.class)
+  public void givenNoValuePart_whenParsingCondition() {
+    NamedList<String> args = new NamedList<>();
+    args.add("must", "OLD.field");
+    args.add("action", "skip");
+    UpsertCondition.parse("bad-rule", args);
+  }
+
+  @Test(expected = SolrException.class)
+  public void givenBadAction_whenParsingCondition() {
+    NamedList<String> args = new NamedList<>();
+    args.add("must", "OLD.field:value");
+    args.add("action", "skippy");
+    UpsertCondition.parse("bad-action", args);
+  }
+
+  @Test
+  public void givenSingleMustClause_whenMatching() {
+    NamedList<String> args = new NamedList<>();
+    args.add("must", "OLD.field:value");
+    args.add("action", "skip");
+
+    UpsertCondition condition = UpsertCondition.parse("skip-it", args);
+
+    assertThat(condition.isSkip(), is(true));
+    assertThat(condition.getName(), is("skip-it"));
+
+    SolrInputDocument oldDoc = new SolrInputDocument();
+    SolrInputDocument newDoc = new SolrInputDocument();
+
+    assertFalse(condition.matches(oldDoc, newDoc));
+
+    oldDoc.setField("field", "value");
+    assertTrue(condition.matches(oldDoc, newDoc));
+
+    oldDoc.setField("field", "not-value");
+    assertFalse(condition.matches(oldDoc, newDoc));
+  }
+
+  @Test
+  public void givenSingleShouldClause_whenMatching() {
+    NamedList<String> args = new NamedList<>();
+    args.add("should", "OLD.field:value");
+    args.add("action", "skip");
+
+    UpsertCondition condition = UpsertCondition.parse("skip-it", args);
+
+    assertThat(condition.isSkip(), is(true));
+    assertThat(condition.getName(), is("skip-it"));
+
+    SolrInputDocument oldDoc = new SolrInputDocument();
+    SolrInputDocument newDoc = new SolrInputDocument();
+
+    assertFalse(condition.matches(oldDoc, newDoc));
+
+    oldDoc.setField("field", "value");
+    assertTrue(condition.matches(oldDoc, newDoc));
+
+    oldDoc.setField("field", "not-value");
+    assertFalse(condition.matches(oldDoc, newDoc));
+  }
+
+  @Test
+  public void givenSingleMustNotClause_whenMatching() {
+    NamedList<String> args = new NamedList<>();
+    args.add("must_not", "OLD.field:value");
+    args.add("action", "skip");
+
+    UpsertCondition condition = UpsertCondition.parse("skip-it", args);
+
+    assertThat(condition.isSkip(), is(true));
+    assertThat(condition.getName(), is("skip-it"));
+
+    SolrInputDocument oldDoc = new SolrInputDocument();
+    SolrInputDocument newDoc = new SolrInputDocument();
+
+    assertTrue(condition.matches(oldDoc, newDoc));
+
+    oldDoc.setField("field", "value");
+    assertFalse(condition.matches(oldDoc, newDoc));
+
+    oldDoc.setField("field", "not-value");
+    assertTrue(condition.matches(oldDoc, newDoc));
+  }
+
+  @Test
+  public void givenMultipleMustClauses_whenMatching() {
+    NamedList<String> args = new NamedList<>();
+    args.add("must", "OLD.field1:value1");
+    args.add("must", "NEW.field2:value2");
+    args.add("action", "skip");
+
+    UpsertCondition condition = UpsertCondition.parse("skip-it", args);
+
+    assertThat(condition.isSkip(), is(true));
+    assertThat(condition.getName(), is("skip-it"));
+
+    SolrInputDocument oldDoc = new SolrInputDocument();
+    SolrInputDocument newDoc = new SolrInputDocument();
+
+    assertFalse(condition.matches(oldDoc, newDoc));
+
+    oldDoc.setField("field1", "value1");
+    assertFalse(condition.matches(oldDoc, newDoc));
+
+    oldDoc.setField("field1", "value1");
+    newDoc.setField("field2", "value2");
+    assertTrue(condition.matches(oldDoc, newDoc));
+
+    oldDoc.setField("field1", "not-value1");
+    newDoc.setField("field2", "value2");
+    assertFalse(condition.matches(oldDoc, newDoc));
+
+    oldDoc.removeField("field1");
+    assertFalse(condition.matches(oldDoc, newDoc));
+  }
+
+  @Test
+  public void givenMultipleShouldClauses_whenMatching() {
+    NamedList<String> args = new NamedList<>();
+    args.add("should", "OLD.field1:value1");
+    args.add("should", "NEW.field2:value2");
+    args.add("action", "skip");
+
+    UpsertCondition condition = UpsertCondition.parse("skip-it", args);
+
+    assertThat(condition.isSkip(), is(true));
+    assertThat(condition.getName(), is("skip-it"));
+
+    SolrInputDocument oldDoc = new SolrInputDocument();
+    SolrInputDocument newDoc = new SolrInputDocument();
+
+    assertFalse(condition.matches(oldDoc, newDoc));
+
+    oldDoc.setField("field1", "value1");
+    assertTrue(condition.matches(oldDoc, newDoc));
+
+    oldDoc.setField("field1", "value1");
+    newDoc.setField("field2", "value2");
+    assertTrue(condition.matches(oldDoc, newDoc));
+
+    oldDoc.setField("field1", "not-value1");
+    newDoc.setField("field2", "value2");
+    assertTrue(condition.matches(oldDoc, newDoc));
+
+    oldDoc.removeField("field1");
+    assertTrue(condition.matches(oldDoc, newDoc));
+
+    newDoc.setField("field2", "not-value2");
+    assertFalse(condition.matches(oldDoc, newDoc));
+  }
+
+  @Test
+  public void givenMustAndMustNotClauses_whenMatching() {
+    NamedList<String> args = new NamedList<>();
+    args.add("must", "OLD.field1:value1");
+    args.add("must_not", "NEW.field2:value2");
+    args.add("action", "skip");
+
+    UpsertCondition condition = UpsertCondition.parse("skip-it", args);
+
+    assertThat(condition.isSkip(), is(true));
+    assertThat(condition.getName(), is("skip-it"));
+
+    SolrInputDocument oldDoc = new SolrInputDocument();
+    SolrInputDocument newDoc = new SolrInputDocument();
+
+    assertFalse(condition.matches(oldDoc, newDoc));
+
+    oldDoc.setField("field1", "value1");
+    assertTrue(condition.matches(oldDoc, newDoc));
+
+    oldDoc.setField("field1", "value1");
+    newDoc.setField("field2", "value2");
+    assertFalse(condition.matches(oldDoc, newDoc));
+
+    oldDoc.setField("field1", "not-value1");
+    newDoc.setField("field2", "value2");
+    assertFalse(condition.matches(oldDoc, newDoc));
+
+    oldDoc.setField("field1", "value1");
+    newDoc.setField("field2", "not-value2");
+    assertTrue(condition.matches(oldDoc, newDoc));
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void givenSkipAction_whenCopyingOldFields() {
+    NamedList<String> args = new NamedList<>();
+    args.add("should", "OLD.field:value");
+    args.add("action", "skip");
+
+    UpsertCondition condition = UpsertCondition.parse("skip-it", args);
+
+    assertThat(condition.isSkip(), is(true));
+    assertThat(condition.getName(), is("skip-it"));
+
+    SolrInputDocument oldDoc = new SolrInputDocument();
+    SolrInputDocument newDoc = new SolrInputDocument();
+
+    condition.copyOldDocFields(oldDoc, newDoc);
+  }
+
+  @Test
+  public void givenUpsertForSpecificFields_whenCopyingOldFields() {
+    NamedList<String> args = new NamedList<>();
+    args.add("must", "OLD.field:value");
+    args.add("action", "upsert:field,other_field");
+
+    UpsertCondition condition = UpsertCondition.parse("upsert", args);
+
+    assertThat(condition.isSkip(), is(false));
+    assertThat(condition.getName(), is("upsert"));
+
+    SolrInputDocument oldDoc = new SolrInputDocument();
+    SolrInputDocument newDoc = new SolrInputDocument();
+    oldDoc.setField("field", "value");
+    oldDoc.setField("other_field", "old-value");
+    oldDoc.setField("not-copied", "not-copied");
+
+    condition.copyOldDocFields(oldDoc, newDoc);
+
+    assertThat(newDoc.getFieldValue("field"), is("value"));
+    assertThat(newDoc.getFieldValue("other_field"), is("old-value"));
+    assertFalse(newDoc.containsKey("not-copied"));
+
+    newDoc = new SolrInputDocument();
+    newDoc.setField("field", "left-alone");
+
+    condition.copyOldDocFields(oldDoc, newDoc);
+
+    assertThat(newDoc.getFieldValue("field"), is("left-alone"));
+    assertThat(newDoc.getFieldValue("other_field"), is("old-value"));
+    assertFalse(newDoc.containsKey("not-copied"));
+  }
+
+  @Test
+  public void givenUpsertForAllFields_whenCopyingOldFields() {
+    NamedList<String> args = new NamedList<>();
+    args.add("must", "OLD.field:value");
+    args.add("action", "upsert:*");
+
+    UpsertCondition condition = UpsertCondition.parse("upsert", args);
+
+    assertThat(condition.isSkip(), is(false));
+    assertThat(condition.getName(), is("upsert"));
+
+    SolrInputDocument oldDoc = new SolrInputDocument();
+    SolrInputDocument newDoc = new SolrInputDocument();
+    oldDoc.setField("field", "value");
+    oldDoc.setField("other_field", "old-value");
+    oldDoc.setField("also-copied", "also-copied");
+
+    condition.copyOldDocFields(oldDoc, newDoc);
+
+    assertThat(newDoc.getFieldValue("field"), is("value"));
+    assertThat(newDoc.getFieldValue("other_field"), is("old-value"));
+    assertThat(newDoc.getFieldValue("also-copied"), is("also-copied"));
+
+    newDoc = new SolrInputDocument();
+    newDoc.setField("field", "left-alone");
+
+    condition.copyOldDocFields(oldDoc, newDoc);
+
+    assertThat(newDoc.getFieldValue("field"), is("left-alone"));
+    assertThat(newDoc.getFieldValue("other_field"), is("old-value"));
+    assertThat(newDoc.getFieldValue("also-copied"), is("also-copied"));
+  }
+}

--- a/solr/core/src/test/org/apache/solr/update/processor/UpsertConditionTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/UpsertConditionTest.java
@@ -92,6 +92,7 @@ public class UpsertConditionTest {
     UpsertCondition condition = UpsertCondition.parse("skip-it", args);
 
     assertThat(condition.isSkip(), is(true));
+    assertThat(condition.isInsert(), is(false));
     assertThat(condition.getName(), is("skip-it"));
 
     SolrInputDocument oldDoc = new SolrInputDocument();
@@ -115,6 +116,7 @@ public class UpsertConditionTest {
     UpsertCondition condition = UpsertCondition.parse("skip-it", args);
 
     assertThat(condition.isSkip(), is(true));
+    assertThat(condition.isInsert(), is(false));
     assertThat(condition.getName(), is("skip-it"));
 
     SolrInputDocument oldDoc = new SolrInputDocument();
@@ -138,6 +140,7 @@ public class UpsertConditionTest {
     UpsertCondition condition = UpsertCondition.parse("skip-it", args);
 
     assertThat(condition.isSkip(), is(true));
+    assertThat(condition.isInsert(), is(false));
     assertThat(condition.getName(), is("skip-it"));
 
     SolrInputDocument oldDoc = new SolrInputDocument();
@@ -161,6 +164,7 @@ public class UpsertConditionTest {
     UpsertCondition condition = UpsertCondition.parse("skip-it", args);
 
     assertThat(condition.isSkip(), is(true));
+    assertThat(condition.isInsert(), is(false));
     assertThat(condition.getName(), is("skip-it"));
 
     SolrInputDocument oldDoc = new SolrInputDocument();
@@ -185,6 +189,7 @@ public class UpsertConditionTest {
     UpsertCondition condition = UpsertCondition.parse("skip-it", args);
 
     assertThat(condition.isSkip(), is(true));
+    assertThat(condition.isInsert(), is(false));
     assertThat(condition.getName(), is("skip-it"));
 
     SolrInputDocument oldDoc = new SolrInputDocument();
@@ -217,6 +222,7 @@ public class UpsertConditionTest {
     UpsertCondition condition = UpsertCondition.parse("skip-it", args);
 
     assertThat(condition.isSkip(), is(true));
+    assertThat(condition.isInsert(), is(false));
     assertThat(condition.getName(), is("skip-it"));
 
     SolrInputDocument oldDoc = new SolrInputDocument();
@@ -252,6 +258,7 @@ public class UpsertConditionTest {
     UpsertCondition condition = UpsertCondition.parse("skip-it", args);
 
     assertThat(condition.isSkip(), is(true));
+    assertThat(condition.isInsert(), is(false));
     assertThat(condition.getName(), is("skip-it"));
 
     SolrInputDocument oldDoc = new SolrInputDocument();
@@ -284,12 +291,55 @@ public class UpsertConditionTest {
     UpsertCondition condition = UpsertCondition.parse("skip-it", args);
 
     assertThat(condition.isSkip(), is(true));
+    assertThat(condition.isInsert(), is(false));
     assertThat(condition.getName(), is("skip-it"));
 
     SolrInputDocument oldDoc = new SolrInputDocument();
     SolrInputDocument newDoc = new SolrInputDocument();
 
     condition.copyOldDocFields(oldDoc, newDoc);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void givenInsertAction_whenCopyingOldFields() {
+    NamedList<String> args = new NamedList<>();
+    args.add("should", "OLD.field:value");
+    args.add("action", "insert");
+
+    UpsertCondition condition = UpsertCondition.parse("insert-it", args);
+
+    assertThat(condition.isSkip(), is(false));
+    assertThat(condition.isInsert(), is(true));
+    assertThat(condition.getName(), is("insert-it"));
+
+    SolrInputDocument oldDoc = new SolrInputDocument();
+    SolrInputDocument newDoc = new SolrInputDocument();
+
+    condition.copyOldDocFields(oldDoc, newDoc);
+  }
+
+  @Test
+  public void givenInsert_whenMatching() {
+    NamedList<String> args = new NamedList<>();
+    args.add("must", "OLD.field:value");
+    args.add("action", "insert");
+
+    UpsertCondition condition = UpsertCondition.parse("insert-it", args);
+
+    assertThat(condition.isSkip(), is(false));
+    assertThat(condition.isInsert(), is(true));
+    assertThat(condition.getName(), is("insert-it"));
+
+    SolrInputDocument oldDoc = new SolrInputDocument();
+    SolrInputDocument newDoc = new SolrInputDocument();
+
+    assertFalse(condition.matches(oldDoc, newDoc));
+
+    oldDoc.setField("field", "value");
+    assertTrue(condition.matches(oldDoc, newDoc));
+
+    oldDoc.setField("field", "not-value");
+    assertFalse(condition.matches(oldDoc, newDoc));
   }
 
   @Test
@@ -301,6 +351,7 @@ public class UpsertConditionTest {
     UpsertCondition condition = UpsertCondition.parse("upsert", args);
 
     assertThat(condition.isSkip(), is(false));
+    assertThat(condition.isInsert(), is(false));
     assertThat(condition.getName(), is("upsert"));
 
     SolrInputDocument oldDoc = new SolrInputDocument();
@@ -334,6 +385,7 @@ public class UpsertConditionTest {
     UpsertCondition condition = UpsertCondition.parse("upsert", args);
 
     assertThat(condition.isSkip(), is(false));
+    assertThat(condition.isInsert(), is(false));
     assertThat(condition.getName(), is("upsert"));
 
     SolrInputDocument oldDoc = new SolrInputDocument();

--- a/solr/core/src/test/org/apache/solr/update/processor/UpsertConditionTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/UpsertConditionTest.java
@@ -142,6 +142,31 @@ public class UpsertConditionTest {
   }
 
   @Test
+  public void givenNumericField_whenMatching() {
+    NamedList<String> args = new NamedList<>(ImmutableMap.of(
+        "must", "OLD.field:123",
+        "action", "skip"
+    ));
+
+    UpsertCondition condition = UpsertCondition.parse("skip-it", args);
+
+    assertThat(condition.isSkip(), is(true));
+    assertThat(condition.isInsert(), is(false));
+    assertThat(condition.getName(), is("skip-it"));
+
+    SolrInputDocument oldDoc = new SolrInputDocument();
+    SolrInputDocument newDoc = new SolrInputDocument();
+
+    assertFalse(condition.matches(oldDoc, newDoc));
+
+    oldDoc.setField("field", 999);
+    assertFalse(condition.matches(oldDoc, newDoc));
+
+    oldDoc.setField("field", 123);
+    assertTrue(condition.matches(oldDoc, newDoc));
+  }
+
+  @Test
   public void givenSingleMustClause_whenMatching() {
     NamedList<String> args = namedList(ImmutableListMultimap.of(
         "must", "OLD.field:value",

--- a/solr/core/src/test/org/apache/solr/update/processor/UpsertConditionTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/UpsertConditionTest.java
@@ -1,5 +1,9 @@
 package org.apache.solr.update.processor;
 
+import java.util.Map;
+
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ListMultimap;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.util.NamedList;
@@ -31,63 +35,67 @@ public class UpsertConditionTest {
 
   @Test(expected = SolrException.class)
   public void givenNoAction_whenParsingCondition() {
-    NamedList<String> args = new NamedList<>();
-    args.add("must", "OLD.field:value");
+    NamedList<String> args = namedList(ImmutableListMultimap.of("must", "OLD.field:value"));
     UpsertCondition.parse("no-action", args);
   }
 
   @Test(expected = SolrException.class)
   public void givenInvalidMatchOccurrence_whenParsingCondition() {
-    NamedList<String> args = new NamedList<>();
-    args.add("maybe_might", "OLD.field:value");
-    args.add("action", "skip");
+    NamedList<String> args = namedList(ImmutableListMultimap.of(
+        "maybe_might", "OLD.field:value",
+        "action", "skip"
+    ));
     UpsertCondition.parse("bad-occurrence", args);
   }
 
   @Test(expected = SolrException.class)
   public void givenNoRules_whenParsingCondition() {
-    NamedList<String> args = new NamedList<>();
-    args.add("action", "skip");
+    NamedList<String> args = namedList(ImmutableListMultimap.of("action", "skip"));
     UpsertCondition.parse("no-rules", args);
   }
 
   @Test(expected = SolrException.class)
   public void givenBadRuleDocPart_whenParsingCondition() {
-    NamedList<String> args = new NamedList<>();
-    args.add("must", "YOUNG.field:value");
-    args.add("action", "skip");
+    NamedList<String> args = namedList(ImmutableListMultimap.of(
+        "must", "YOUNG.field:value",
+        "action", "skip"
+    ));
     UpsertCondition.parse("bad-rule", args);
   }
 
   @Test(expected = SolrException.class)
   public void givenNoDocPart_whenParsingCondition() {
-    NamedList<String> args = new NamedList<>();
-    args.add("must", "field:value");
-    args.add("action", "skip");
+    NamedList<String> args = namedList(ImmutableListMultimap.of(
+        "must", "field:value",
+        "action", "skip"
+    ));
     UpsertCondition.parse("bad-rule", args);
   }
 
   @Test(expected = SolrException.class)
   public void givenNoValuePart_whenParsingCondition() {
-    NamedList<String> args = new NamedList<>();
-    args.add("must", "OLD.field");
-    args.add("action", "skip");
+    NamedList<String> args = namedList(ImmutableListMultimap.of(
+        "must", "OLD.field",
+        "action", "skip"
+    ));
     UpsertCondition.parse("bad-rule", args);
   }
 
   @Test(expected = SolrException.class)
   public void givenBadAction_whenParsingCondition() {
-    NamedList<String> args = new NamedList<>();
-    args.add("must", "OLD.field:value");
-    args.add("action", "skippy");
+    NamedList<String> args = namedList(ImmutableListMultimap.of(
+        "must", "OLD.field:value",
+        "action", "skippy"
+    ));
     UpsertCondition.parse("bad-action", args);
   }
 
   @Test
   public void givenSingleMustClause_whenMatching() {
-    NamedList<String> args = new NamedList<>();
-    args.add("must", "OLD.field:value");
-    args.add("action", "skip");
+    NamedList<String> args = namedList(ImmutableListMultimap.of(
+        "must", "OLD.field:value",
+        "action", "skip"
+    ));
 
     UpsertCondition condition = UpsertCondition.parse("skip-it", args);
 
@@ -109,9 +117,10 @@ public class UpsertConditionTest {
 
   @Test
   public void givenSingleShouldClause_whenMatching() {
-    NamedList<String> args = new NamedList<>();
-    args.add("should", "OLD.field:value");
-    args.add("action", "skip");
+    NamedList<String> args = namedList(ImmutableListMultimap.of(
+        "should", "OLD.field:value",
+        "action", "skip"
+    ));
 
     UpsertCondition condition = UpsertCondition.parse("skip-it", args);
 
@@ -133,9 +142,10 @@ public class UpsertConditionTest {
 
   @Test
   public void givenSingleMustNotClause_whenMatching() {
-    NamedList<String> args = new NamedList<>();
-    args.add("must_not", "OLD.field:value");
-    args.add("action", "skip");
+    NamedList<String> args = namedList(ImmutableListMultimap.of(
+        "must_not", "OLD.field:value",
+        "action", "skip"
+    ));
 
     UpsertCondition condition = UpsertCondition.parse("skip-it", args);
 
@@ -157,9 +167,10 @@ public class UpsertConditionTest {
 
   @Test
   public void givenSingleShouldAnyValueClause_whenMatching() {
-    NamedList<String> args = new NamedList<>();
-    args.add("should", "OLD.field:*");
-    args.add("action", "skip");
+    NamedList<String> args = namedList(ImmutableListMultimap.of(
+        "should", "OLD.field:*",
+        "action", "skip"
+    ));
 
     UpsertCondition condition = UpsertCondition.parse("skip-it", args);
 
@@ -181,10 +192,11 @@ public class UpsertConditionTest {
 
   @Test
   public void givenMultipleMustClauses_whenMatching() {
-    NamedList<String> args = new NamedList<>();
-    args.add("must", "OLD.field1:value1");
-    args.add("must", "NEW.field2:value2");
-    args.add("action", "skip");
+    NamedList<String> args = namedList(ImmutableListMultimap.of(
+        "must", "OLD.field1:value1",
+        "must", "NEW.field2:value2",
+        "action", "skip"
+    ));
 
     UpsertCondition condition = UpsertCondition.parse("skip-it", args);
 
@@ -214,10 +226,11 @@ public class UpsertConditionTest {
 
   @Test
   public void givenMultipleShouldClauses_whenMatching() {
-    NamedList<String> args = new NamedList<>();
-    args.add("should", "OLD.field1:value1");
-    args.add("should", "NEW.field2:value2");
-    args.add("action", "skip");
+    NamedList<String> args = namedList(ImmutableListMultimap.of(
+        "should", "OLD.field1:value1",
+        "should", "NEW.field2:value2",
+        "action", "skip"
+    ));
 
     UpsertCondition condition = UpsertCondition.parse("skip-it", args);
 
@@ -250,10 +263,11 @@ public class UpsertConditionTest {
 
   @Test
   public void givenMustAndMustNotClauses_whenMatching() {
-    NamedList<String> args = new NamedList<>();
-    args.add("must", "OLD.field1:value1");
-    args.add("must_not", "NEW.field2:value2");
-    args.add("action", "skip");
+    NamedList<String> args = namedList(ImmutableListMultimap.of(
+        "must", "OLD.field1:value1",
+        "must_not", "NEW.field2:value2",
+        "action", "skip"
+    ));
 
     UpsertCondition condition = UpsertCondition.parse("skip-it", args);
 
@@ -284,9 +298,10 @@ public class UpsertConditionTest {
 
   @Test(expected = IllegalStateException.class)
   public void givenSkipAction_whenCopyingOldFields() {
-    NamedList<String> args = new NamedList<>();
-    args.add("should", "OLD.field:value");
-    args.add("action", "skip");
+    NamedList<String> args = namedList(ImmutableListMultimap.of(
+        "should", "OLD.field:value",
+        "action", "skip"
+    ));
 
     UpsertCondition condition = UpsertCondition.parse("skip-it", args);
 
@@ -302,9 +317,10 @@ public class UpsertConditionTest {
 
   @Test(expected = IllegalStateException.class)
   public void givenInsertAction_whenCopyingOldFields() {
-    NamedList<String> args = new NamedList<>();
-    args.add("should", "OLD.field:value");
-    args.add("action", "insert");
+    NamedList<String> args = namedList(ImmutableListMultimap.of(
+        "should", "OLD.field:value",
+        "action", "insert"
+    ));
 
     UpsertCondition condition = UpsertCondition.parse("insert-it", args);
 
@@ -320,9 +336,10 @@ public class UpsertConditionTest {
 
   @Test
   public void givenInsert_whenMatching() {
-    NamedList<String> args = new NamedList<>();
-    args.add("must", "OLD.field:value");
-    args.add("action", "insert");
+    NamedList<String> args = namedList(ImmutableListMultimap.of(
+        "must", "OLD.field:value",
+        "action", "insert"
+    ));
 
     UpsertCondition condition = UpsertCondition.parse("insert-it", args);
 
@@ -344,9 +361,10 @@ public class UpsertConditionTest {
 
   @Test
   public void givenUpsertForSpecificFields_whenCopyingOldFields() {
-    NamedList<String> args = new NamedList<>();
-    args.add("must", "OLD.field:value");
-    args.add("action", "upsert:field,other_field");
+    NamedList<String> args = namedList(ImmutableListMultimap.of(
+        "must", "OLD.field:value",
+        "action", "upsert:field,other_field"
+    ));
 
     UpsertCondition condition = UpsertCondition.parse("upsert", args);
 
@@ -378,9 +396,10 @@ public class UpsertConditionTest {
 
   @Test
   public void givenUpsertForAllFields_whenCopyingOldFields() {
-    NamedList<String> args = new NamedList<>();
-    args.add("must", "OLD.field:value");
-    args.add("action", "upsert:*");
+    NamedList<String> args = namedList(ImmutableListMultimap.of(
+        "must", "OLD.field:value",
+        "action", "upsert:*"
+    ));
 
     UpsertCondition condition = UpsertCondition.parse("upsert", args);
 
@@ -409,4 +428,9 @@ public class UpsertConditionTest {
     assertThat(newDoc.getFieldValue("other_field"), is("old-value"));
     assertThat(newDoc.getFieldValue("also-copied"), is("also-copied"));
   }
+
+  private<T> NamedList<T> namedList(ListMultimap<String, T> values) {
+    return new NamedList<>(values.entries().toArray(new Map.Entry[0]));
+  }
+
 }

--- a/solr/core/src/test/org/apache/solr/update/processor/UpsertConditionTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/UpsertConditionTest.java
@@ -530,6 +530,26 @@ public class UpsertConditionTest {
   }
 
   @Test
+  public void givenUpsertAndNoOldDoc_whenRunning() {
+    NamedList<String> args = namedList(ImmutableListMultimap.of(
+        "must", "NEW.field:value",
+        "action", "upsert:field,other_field"
+    ));
+
+    UpsertCondition condition = UpsertCondition.parse("upsert", args);
+
+    assertThat(condition.getName(), is("upsert"));
+
+    SolrInputDocument newDoc = new SolrInputDocument();
+    newDoc.setField("field", "left-alone");
+
+    assertThat(condition.run(null, newDoc), is(UpsertCondition.ActionType.UPSERT));
+
+    assertThat(newDoc.getFieldValue("field"), is("left-alone"));
+  }
+
+
+  @Test
   public void givenNullify_whenRunning() {
     NamedList<String> args = namedList(ImmutableListMultimap.of(
         "must", "OLD.field:value",

--- a/solr/core/src/test/org/apache/solr/update/processor/UpsertConditionTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/UpsertConditionTest.java
@@ -114,6 +114,34 @@ public class UpsertConditionTest {
   }
 
   @Test
+  public void givenMultiValuedField_whenMatching() {
+    NamedList<String> args = new NamedList<>(ImmutableMap.of(
+        "must", "OLD.field:value",
+        "action", "skip"
+    ));
+
+    UpsertCondition condition = UpsertCondition.parse("skip-it", args);
+
+    assertThat(condition.isSkip(), is(true));
+    assertThat(condition.isInsert(), is(false));
+    assertThat(condition.getName(), is("skip-it"));
+
+    SolrInputDocument oldDoc = new SolrInputDocument();
+    SolrInputDocument newDoc = new SolrInputDocument();
+
+    assertFalse(condition.matches(oldDoc, newDoc));
+
+    oldDoc.addField("field", "other1");
+    assertFalse(condition.matches(oldDoc, newDoc));
+
+    oldDoc.addField("field", "value");
+    assertTrue(condition.matches(oldDoc, newDoc));
+
+    oldDoc.addField("field", "other2");
+    assertTrue(condition.matches(oldDoc, newDoc));
+  }
+
+  @Test
   public void givenSingleMustClause_whenMatching() {
     NamedList<String> args = namedList(ImmutableListMultimap.of(
         "must", "OLD.field:value",


### PR DESCRIPTION
This is intended to make it possible to support out of order compliance (and potentially metric update) messages.  I've made it fairly general so it's potentially possible to get this upstreamed in the future.

The rules are configured for the document update processor like:

```
         <lst name="existingPermanentDeletes">
            <str name="must">OLD.compliance_reason:delete</str>
            <str name="action">skip</str>
          </lst>
          <lst name="existingSoftDeletes">
            <str name="must">OLD.compliance_reason:soft_delete</str>
            <str name="action">upsert:compliance_reason</str>
          </lst>
          <lst name="newSoftDeletes">
            <str name="must">NEW.compliance_reason:soft_delete</str>
            <str name="action">upsert:*</str>
          </lst>
```

There can be multiple conditions and they are checked in order - the first one that matches wins.

The matching of clauses can be defined in a similar way to lucene:

* `must` - required to match
* `must_not` - required to not match
* `should` - at least one is required match

The clauses themselves look like:

* `OLD.my_field:the_value` - the document already in solr has a field called `my_field` with the value `the_value`
* `OLD.my_field:*` - the document already in solr has a field called `my_field` with any value
* `OLD.*` - the document already in solr exists
* `NEW.my_field:the_value` - the document about to be written has a field called `my_field` with the value `the_value`

The actions can look like:

* `skip` - don't write the new document at all
* `insert` - carry on as normal and write the document
* `upsert:*` - merge the document with the existing document in solr (if there is one) - copying over all fields not on the new document
* `upsert:my_field` - merge the document with the existing document in solr (if there is one) - copying over just `my_field`
* `upsert:my_field1,myfield2` - merge the document with the existing document in solr (if there is one) - copying over just `my_field1` & `my_field2`