### PR TITLE
Revert "Adding AWS dependencies"

### DIFF
--- a/lucene/ivy-versions.properties
+++ b/lucene/ivy-versions.properties
@@ -162,12 +162,6 @@ org.apache.hadoop.version = 2.8.1
 /org.apache.hadoop/hadoop-hdfs = ${org.apache.hadoop.version}
 /org.apache.hadoop/hadoop-hdfs-client = ${org.apache.hadoop.version}
 /org.apache.hadoop/hadoop-minikdc = ${org.apache.hadoop.version}
-/org.apache.hadoop/hadoop-aws = ${org.apache.hadoop.version}
-
-com.amazonaws.version = 1.11.136
-/com.amazonaws/aws-java-sdk-s3 = ${com.amazonaws.version}
-/com.amazonaws/aws-java-sdk-kms = ${com.amazonaws.version}
-/com.amazonaws/aws-java-sdk-core = ${com.amazonaws.version}
 
 /org.apache.htrace/htrace-core4 = 4.2.0-incubating
 

--- a/solr/core/ivy.xml
+++ b/solr/core/ivy.xml
@@ -79,12 +79,7 @@
     <dependency org="org.apache.hadoop" name="hadoop-auth" rev="${/org.apache.hadoop/hadoop-auth}" conf="compile.hadoop"/>
     <dependency org="commons-configuration" name="commons-configuration" rev="${/commons-configuration/commons-configuration}" conf="compile.hadoop"/>
     <dependency org="commons-collections" name="commons-collections" rev="${/commons-collections/commons-collections}" conf="compile.hadoop"/>
-    <dependency org="org.apache.hadoop" name="hadoop-aws" rev="${/org.apache.hadoop/hadoop-aws}" conf="compile.hadoop"/>
     
-    <dependency org="com.amazonaws" name="aws-java-sdk-s3" rev="${/com.amazonaws/aws-java-sdk-s3}" conf="compile.hadoop"/>
-    <dependency org="com.amazonaws" name="aws-java-sdk-kms" rev="${/com.amazonaws/aws-java-sdk-kms}" conf="compile.hadoop"/>
-    <dependency org="com.amazonaws" name="aws-java-sdk-core" rev="${/com.amazonaws/aws-java-sdk-core}" conf="compile.hadoop"/>
-
     <dependency org="com.google.protobuf" name="protobuf-java" rev="${/com.google.protobuf/protobuf-java}" conf="compile.hadoop"/>
     <dependency org="com.github.ben-manes.caffeine" name="caffeine" rev="${/com.github.ben-manes.caffeine/caffeine}" conf="compile.hadoop"/>
     <dependency org="org.apache.htrace" name="htrace-core4" rev="${/org.apache.htrace/htrace-core4}" conf="compile.hadoop"/>


### PR DESCRIPTION
The aws dependencies that I included > 2 years ago actually conflict with the plugin work I'm working on. It seemed most sense to entirely remove this inclusion so we're also 1 step closer to removing custom alterations/patches we've made for our solr build in hopes of using a public solr image