### PR TITLE
Fix UpsertCondition due to Solr 7 encoding of String types in javabin…

### DIFF
--- a/solr/core/src/java/org/apache/solr/update/processor/UpsertCondition.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/UpsertCondition.java
@@ -399,13 +399,13 @@ class UpsertCondition {
         return null;
       }
       Object fieldValue = doc.getFieldValue(fieldName);
-      if (fieldValue instanceof String) {
-        return (String)fieldValue;
+      if (fieldValue instanceof CharSequence) {
+        return fieldValue.toString();
       }
       if (fieldValue instanceof Map) {
         final Object setValue = ((Map)fieldValue).get("set");
-        if (setValue instanceof String) {
-          return (String)setValue;
+        if (setValue instanceof CharSequence) {
+          return setValue.toString();
         }
       }
       // Cannot support non-String types or collection (multi-valued field) types

--- a/solr/core/src/test/org/apache/solr/update/processor/UpsertConditionTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/UpsertConditionTest.java
@@ -10,6 +10,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ListMultimap;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrInputDocument;
+import org.apache.solr.common.util.ByteArrayUtf8CharSequence;
 import org.apache.solr.common.util.NamedList;
 import org.junit.Test;
 
@@ -873,6 +874,19 @@ public class UpsertConditionTest {
     }
 
     {
+      // Same test but simulating how the javabin format encodes strings
+      SolrInputDocument newDoc = new SolrInputDocument();
+      newDoc.setField("model_name", new ByteArrayUtf8CharSequence("Macbook"));
+      SolrInputDocument oldDoc = new SolrInputDocument();
+      oldDoc.setField("model_name", "Powerbook");
+      oldDoc.setField("colour", "Silver");
+      oldDoc.setField("sku", "PowerbookSilver");
+      assertTrue(condition.matches(oldDoc, newDoc));
+      assertThat(condition.run(oldDoc, newDoc), is(UpsertCondition.ActionType.CONCAT));
+      assertThat(newDoc.getFieldValue("sku"), is("MacbookSilver"));
+    }
+
+    {
       SolrInputDocument newDoc = new SolrInputDocument();
       newDoc.setField("model_name", "Macbook");
       newDoc.setField("sku", "CustomOverride");
@@ -957,6 +971,20 @@ public class UpsertConditionTest {
     {
       SolrInputDocument newDoc = new SolrInputDocument();
       newDoc.setField("model_name", Collections.singletonMap("set", "Macbook"));
+      SolrInputDocument oldDoc = new SolrInputDocument();
+      oldDoc.setField("model_name", "Powerbook");
+      oldDoc.setField("colour", "Silver");
+      oldDoc.setField("sku", "PowerbookSilver");
+      assertTrue(condition.matches(oldDoc, newDoc));
+      assertThat(condition.run(oldDoc, newDoc), is(UpsertCondition.ActionType.CONCAT));
+      assertThat(newDoc.getFieldValue("sku"), is("MacbookSilver"));
+    }
+
+    {
+      // Same test but simulating how the javabin format encodes strings
+      SolrInputDocument newDoc = new SolrInputDocument();
+      newDoc.setField("model_name",
+          Collections.singletonMap("set", new ByteArrayUtf8CharSequence("Macbook")));
       SolrInputDocument oldDoc = new SolrInputDocument();
       oldDoc.setField("model_name", "Powerbook");
       oldDoc.setField("colour", "Silver");


### PR DESCRIPTION
… format.

This relates to a change in behaviour introduced in SOLR-12983 which affected how javabin encodes strings, they are ByteArrayUtf8CharSequence and not String objects (but both are CharSequence). A similar problem with UpdateRequestProcessors was noted and fixed in SOLR-13255 but that did not fix the case of Atomic Updates where the field is a Map from operation->value and hence the value was not a String anymore, but a ByteArrayUtf8CharSequence.